### PR TITLE
Fix publish action

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -57,6 +57,8 @@ jobs:
         uses: actions/checkout@v2
       - name: Setup Python
         uses: actions/setup-python@v2
+        with:
+          python-version: 3.7
       - name: Build package
         run: make
       - name: Publish a Python distribution to PyPI

--- a/openfisca_uk/tools/datasets.yml
+++ b/openfisca_uk/tools/datasets.yml
@@ -1,1 +1,1 @@
-default: synth_frs
+default: frs_was_imp


### PR DESCRIPTION
The last PR merged failed to publish, because the publish action used Python 3.10 and therefore failed to install.