### PR TITLE
Param uprating

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ format:
 	autopep8 -r .
 	black . -l 79
 
-test: 
+test:
 	openfisca test -c openfisca_uk openfisca_uk/tests/policy/baseline
 	openfisca test -c openfisca_uk openfisca_uk/tests/policy/reforms/with_postcode_features -r openfisca_uk.config.postcode_lookup.with_postcode_features
 	pytest openfisca_uk/tests/code_health -vv

--- a/docs/summary/generate_summary.py
+++ b/docs/summary/generate_summary.py
@@ -1,0 +1,30 @@
+from argparse import ArgumentParser
+from openfisca_uk import Microsimulation
+from openfisca_uk_data import FRS
+import yaml
+from rdbl import num
+
+def main():
+    sim = Microsimulation(dataset=FRS)
+    year = 2022
+
+    percentage = lambda x: f"{round(x * 100, 2)}%"
+
+    results = {
+        "Poverty rate (BHC)": percentage(sim.calc('in_poverty_bhc', map_to='person', period=year).mean()),
+        "Poverty rate (AHC)": percentage(sim.calc('in_poverty_ahc', map_to='person', period=year).mean()),
+        "Income Tax revenue": num(sim.calc("income_tax", period=year).sum()),
+        "National Insurance (employee-side) revenue": num(sim.calc("national_insurance", period=year).sum()),
+        "Employment income": num(sim.calc("employment_income", period=year).sum()),
+        "Total income": num(sim.calc("total_income", period=year).sum()),
+        "Benefit expenditure": num(sim.calc("benefits", period=year).sum()),
+    }
+
+    with open("docs/summary/summary.yaml", "w+") as f:
+        yaml.dump(results, f)
+    
+
+if __name__ == "__main__":
+    parser = ArgumentParser(description="Generate a summary of the tax-benefit system")
+    args = parser.parse_args()
+    main()

--- a/docs/summary/generate_summary.py
+++ b/docs/summary/generate_summary.py
@@ -2,29 +2,45 @@ from argparse import ArgumentParser
 from openfisca_uk import Microsimulation
 from openfisca_uk_data import FRS
 import yaml
-from rdbl import num
+
+
+def percentage(x: float) -> str:
+    return f"{round(x * 100, 2)}%"
+
+
+def gbp(x: float) -> str:
+    return f"{round(x / 1e9, 1):,}bn"
+
 
 def main():
     sim = Microsimulation(dataset=FRS)
     year = 2022
 
-    percentage = lambda x: f"{round(x * 100, 2)}%"
-
     results = {
-        "Poverty rate (BHC)": percentage(sim.calc('in_poverty_bhc', map_to='person', period=year).mean()),
-        "Poverty rate (AHC)": percentage(sim.calc('in_poverty_ahc', map_to='person', period=year).mean()),
-        "Income Tax revenue": num(sim.calc("income_tax", period=year).sum()),
-        "National Insurance (employee-side) revenue": num(sim.calc("national_insurance", period=year).sum()),
-        "Employment income": num(sim.calc("employment_income", period=year).sum()),
-        "Total income": num(sim.calc("total_income", period=year).sum()),
-        "Benefit expenditure": num(sim.calc("benefits", period=year).sum()),
+        "Poverty rate (BHC)": percentage(
+            sim.calc("in_poverty_bhc", map_to="person", period=year).mean()
+        ),
+        "Poverty rate (AHC)": percentage(
+            sim.calc("in_poverty_ahc", map_to="person", period=year).mean()
+        ),
+        "Income Tax revenue": gbp(sim.calc("income_tax", period=year).sum()),
+        "National Insurance (employee-side) revenue": gbp(
+            sim.calc("national_insurance", period=year).sum()
+        ),
+        "Employment income": gbp(
+            sim.calc("employment_income", period=year).sum()
+        ),
+        "Total income": gbp(sim.calc("total_income", period=year).sum()),
+        "Benefit expenditure": gbp(sim.calc("benefits", period=year).sum()),
     }
 
     with open("docs/summary/summary.yaml", "w+") as f:
         yaml.dump(results, f)
-    
+
 
 if __name__ == "__main__":
-    parser = ArgumentParser(description="Generate a summary of the tax-benefit system")
+    parser = ArgumentParser(
+        description="Generate a summary of the tax-benefit system"
+    )
     args = parser.parse_args()
     main()

--- a/docs/summary/summary.yaml
+++ b/docs/summary/summary.yaml
@@ -1,7 +1,7 @@
-Benefit expenditure: 222bn
-Employment income: 832bn
-Income Tax revenue: 180bn
+Benefit expenditure: 222.4bn
+Employment income: 832.4bn
+Income Tax revenue: 179.6bn
 National Insurance (employee-side) revenue: 64.2bn
 Poverty rate (AHC): 18.78%
 Poverty rate (BHC): 15.95%
-Total income: 1tr
+Total income: 1,222.7bn

--- a/docs/summary/summary.yaml
+++ b/docs/summary/summary.yaml
@@ -1,0 +1,7 @@
+Benefit expenditure: 222bn
+Employment income: 832bn
+Income Tax revenue: 180bn
+National Insurance (employee-side) revenue: 64.2bn
+Poverty rate (AHC): 18.78%
+Poverty rate (BHC): 15.95%
+Total income: 1tr

--- a/openfisca_uk/parameters/poverty/absolute_poverty_threshold_ahc.yaml
+++ b/openfisca_uk/parameters/poverty/absolute_poverty_threshold_ahc.yaml
@@ -1,8 +1,12 @@
 description: Absolute poverty threshold for equivalised household net income, after housing costs.
 values:
-  2015-06-01:
-    value: 270
+  2010-01-01:
+    value: 215.4
 metadata:
   period: week
   unit: currency-GBP
-  reference: https://www.ifs.org.uk/comms/comm118.pdf#page=7
+  reference: 
+    title: Households Below Average income, 2010/11
+    href: https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/200720/full_hbai12.pdf#page=35
+  uprating:
+    parameter: uprating.CPI

--- a/openfisca_uk/parameters/poverty/absolute_poverty_threshold_bhc.yaml
+++ b/openfisca_uk/parameters/poverty/absolute_poverty_threshold_bhc.yaml
@@ -1,8 +1,12 @@
 description: Absolute poverty threshold for equivalised household net income, before housing costs.
 values:
-  2015-06-05:
-    value: 316
+  2010-01-01:
+    value: 251.4
 metadata:
   period: week
   unit: currency-GBP
-  reference: https://www.ifs.org.uk/comms/comm118.pdf#page=7
+  reference: 
+    title: Households Below Average income, 2010/11
+    href: https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/200720/full_hbai12.pdf#page=35
+  uprating:
+    parameter: uprating.CPI

--- a/openfisca_uk/parameters/uprating/CPI.yaml
+++ b/openfisca_uk/parameters/uprating/CPI.yaml
@@ -1,5 +1,10 @@
 description: Harmonised CPI index
 values:
+  2010-01-01: 90.1
+  2011-01-01: 93.6
+  2012-01-01: 96.0
+  2013-01-01: 98.4
+  2014-01-01: 99.6
   2015-01-01: 100.00
   2018-01-01: 106.40
   2019-01-01: 108.20
@@ -13,4 +18,8 @@ values:
   2024-01-01: 117.11
 metadata:
   unit: currency-GBP
-  reference: https://www.microsimulation.ac.uk/wp-content/uploads/2020/10/cempa7-20.pdf#page=109
+  reference: 
+    - title: ONS
+      href: https://www.ons.gov.uk/economy/inflationandpriceindices/timeseries/l522/mm23
+    - title: UKMOD Country Report
+      href: https://www.microsimulation.ac.uk/wp-content/uploads/2020/10/cempa7-20.pdf#page=109

--- a/openfisca_uk/system.py
+++ b/openfisca_uk/system.py
@@ -4,7 +4,7 @@ import os
 from openfisca_uk import entities
 import os
 from openfisca_core.taxbenefitsystems import TaxBenefitSystem
-from openfisca_tools.parameters import interpolate_parameters
+from openfisca_tools.parameters import interpolate_parameters, uprate_parameters
 
 COUNTRY_DIR = os.path.dirname(os.path.abspath(__file__))
 
@@ -26,6 +26,7 @@ class CountryTaxBenefitSystem(TaxBenefitSystem):
         self.load_parameters(param_path)
 
         self.parameters = interpolate_parameters(self.parameters)
+        self.parameters = uprate_parameters(self.parameters)
 
         # We define which variable, parameter and simulation example will be used in the OpenAPI specification
         self.open_api_config = {

--- a/openfisca_uk/system.py
+++ b/openfisca_uk/system.py
@@ -4,7 +4,10 @@ import os
 from openfisca_uk import entities
 import os
 from openfisca_core.taxbenefitsystems import TaxBenefitSystem
-from openfisca_tools.parameters import interpolate_parameters, uprate_parameters
+from openfisca_tools.parameters import (
+    interpolate_parameters,
+    uprate_parameters,
+)
 
 COUNTRY_DIR = os.path.dirname(os.path.abspath(__file__))
 

--- a/openfisca_uk/tests/policy/baseline/demographic/poverty.yaml
+++ b/openfisca_uk/tests/policy/baseline/demographic/poverty.yaml
@@ -6,6 +6,6 @@
     net_income: 0
     is_household_head: true
   output:
-    poverty_gap_bhc: 211 * 52
+    poverty_gap_bhc: 229 * 52
     in_poverty_bhc: true
     in_deep_poverty_bhc: true

--- a/openfisca_uk/tests/policy/baseline/demographic/poverty.yaml
+++ b/openfisca_uk/tests/policy/baseline/demographic/poverty.yaml
@@ -6,6 +6,6 @@
     net_income: 0
     is_household_head: true
   output:
-    poverty_gap_bhc: 229 * 52
+    poverty_gap_bhc: 202 * 52
     in_poverty_bhc: true
     in_deep_poverty_bhc: true

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
         "OpenFisca-Core>=35.4.1",
         "microdf_python>=0.3.0",
         "OpenFisca-UK-Data>=0.3.1,<0.4.0",
-        "OpenFisca-Tools>=0.1.3,<0.2.0",
+        "OpenFisca-Tools>=0.1.4,<0.2.0",
         "tqdm>=4.59.0",
         "plotly>=4.14.3",
         "argparse>=1.4.0",

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="OpenFisca-UK",
-    version="0.7.2",
+    version="0.7.3",
     author="PolicyEngine",
     author_email="nikhil@policyengine.org",
     classifiers=[


### PR DESCRIPTION
Adds improvements to poverty calculations, including:
* Using primary sources and calculating poverty thresholds from said sources (i.e. from the actual definition - 60% of median income bhc/ahc in 2010, uprating with CPI, rather than taking an intermediate IFS result from 2015 and uprating from that year)
* Using the new parameter uprating tools in openfisca-tools (requires https://github.com/PolicyEngine/openfisca-tools/pull/6)
* Add a short summary-printing script, for easy diff viewing in future (could be executed automatically in future, but the functionality is now there should we want to check future PRs)