### PR TITLE
Assign CT to household head rather than household

### DIFF
--- a/openfisca_uk/variables/finance/income.py
+++ b/openfisca_uk/variables/finance/income.py
@@ -99,7 +99,11 @@ class net_income(Variable):
     definition_period = YEAR
 
     def formula(person, period, parameters):
-        return person("gross_income", period) - person("tax", period)
+        income = person("gross_income", period) - person("tax", period)
+        ct_payment = person("is_household_head", period) * person.household(
+            "council_tax", period
+        )
+        return income - ct_payment
 
 
 class hours_worked(Variable):
@@ -193,11 +197,7 @@ class household_net_income(Variable):
     definition_period = YEAR
 
     def formula(household, period, parameters):
-        return max_(
-            0,
-            aggr(household, period, ["net_income"])
-            - household("council_tax", period),
-        )
+        return max_(0, aggr(household, period, ["net_income"]))
 
 
 class household_net_income_ahc(Variable):

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="OpenFisca-UK",
-    version="0.7.3",
+    version="0.7.4",
     author="PolicyEngine",
     author_email="nikhil@policyengine.org",
     classifiers=[


### PR DESCRIPTION
This is needed for PolicyEngine to correctly calculate the budgetary impact (it looks at `net_income` rather than `household_net_income`).