### PR TITLE
Update UC changes per Autumn Budget and legislation

### DIFF
--- a/openfisca_uk/parameters/benefit/universal_credit/means_test/reduction_rate.yaml
+++ b/openfisca_uk/parameters/benefit/universal_credit/means_test/reduction_rate.yaml
@@ -1,16 +1,12 @@
 description: Rate at which Universal Credit is reduced with earnings above the work allowance
 values:
-  # Universal Credit Regulations.
   2013-04-29: 0.65
   2017-04-10: 0.63
-  # Autumn Budget and Spending Review 2021.
-  2021-12-01: 0.55
+  2021-11-24: 0.55
 metadata:
   label: Universal Credit reduction rate
   name: UC_reduction_rate
   unit: /1
   reference:
-    - name: The Universal Credit Regulations 2013
-      href: https://www.legislation.gov.uk/uksi/2013/376/regulation/22/2021-04-12
-    - name: Autumn Budget and Spending Review 2021
-      href: https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/1028813/Budget_AB2021_Print.pdf#page=138 
+    name: The Universal Credit Regulations 2013
+    href: https://www.legislation.gov.uk/uksi/2013/376/regulation/22

--- a/openfisca_uk/parameters/benefit/universal_credit/means_test/work_allowance_with_housing.yaml
+++ b/openfisca_uk/parameters/benefit/universal_credit/means_test/work_allowance_with_housing.yaml
@@ -6,15 +6,13 @@ values:
   2019-04-08: 287
   2020-04-06: 292
   2021-04-12: 293
-  # Autumn Budget and Spending Review 2021 increases work allowance by £50.
-  2021-12-01: 335
+  2021-11-24: 335
 metadata:
   label: Universal Credit Work Allowance with housing support
   name: UC_work_allowance_with_housing
   period: month
   unit: currency-GBP
   reference:
-    - name: The Universal Credit Regulations 2013
-      href: https://www.legislation.gov.uk/uksi/2013/376/regulation/22/2021-04-12
-    - name: Autumn Budget and Spending Review 2021
-      href: https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/1028813/Budget_AB2021_Print.pdf#page=138 
+    name: The Universal Credit Regulations 2013
+    href: https://www.legislation.gov.uk/uksi/2013/376/regulation/22
+    

--- a/openfisca_uk/parameters/benefit/universal_credit/means_test/work_allowance_with_housing.yaml
+++ b/openfisca_uk/parameters/benefit/universal_credit/means_test/work_allowance_with_housing.yaml
@@ -15,4 +15,3 @@ metadata:
   reference:
     name: The Universal Credit Regulations 2013
     href: https://www.legislation.gov.uk/uksi/2013/376/regulation/22
-    

--- a/openfisca_uk/parameters/benefit/universal_credit/means_test/work_allowance_without_housing.yaml
+++ b/openfisca_uk/parameters/benefit/universal_credit/means_test/work_allowance_without_housing.yaml
@@ -6,15 +6,12 @@ values:
   2019-04-08: 503
   2020-04-06: 512
   2021-04-12: 515
-  # Autumn Budget and Spending Review 2021 increases work allowance by £50.
-  2021-12-01: 557
+  2021-11-24: 557
 metadata:
   label: Universal Credit Work Allowance without housing support
   name: UC_work_allowance_without_housing
   period: month
   unit: currency-GBP
   reference:
-  - name: The Universal Credit Regulations 2013
-    href: https://www.legislation.gov.uk/uksi/2013/376/regulation/22/2021-04-12
-  - name: Autumn Budget and Spending Review 2021
-    href: https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/1028813/Budget_AB2021_Print.pdf#page=138 
+    name: The Universal Credit Regulations 2013
+    href: https://www.legislation.gov.uk/uksi/2013/376/regulation/22


### PR DESCRIPTION
* Minor change.
* Impacted periods: from 2021-11-24
* Impacted areas: `parameters/benefit/universal_credit/means_test`
* Details:
  - Shift Autumn Budget UC changes from 2021-12-01 to 2021-11-24
  - Remove Autumn Budget reference, use legislation

- - - -

These changes:

- Fix or improve an already existing calculation.