### PR TITLE
Change hours_worked label to 'Hours worked per week'

### DIFF
--- a/changelog.d/451.md
+++ b/changelog.d/451.md
@@ -1,1 +1,1 @@
-- Change `hours_worked` variable label to "Hours worked per week" for clarity
+- Change `hours_worked` variable label to "Annual hours worked" for clarity.

--- a/changelog.d/451.md
+++ b/changelog.d/451.md
@@ -1,0 +1,1 @@
+- Change `hours_worked` variable label to "Hours worked per week" for clarity

--- a/policyengine_uk/variables/household/income/hours_worked.py
+++ b/policyengine_uk/variables/household/income/hours_worked.py
@@ -6,6 +6,6 @@ import numpy as np
 class hours_worked(Variable):
     value_type = float
     entity = Person
-    label = "Hours worked per week"
+    label = "Annual hours worked"
     definition_period = YEAR
     unit = "hour"

--- a/policyengine_uk/variables/household/income/hours_worked.py
+++ b/policyengine_uk/variables/household/income/hours_worked.py
@@ -6,6 +6,6 @@ import numpy as np
 class hours_worked(Variable):
     value_type = float
     entity = Person
-    label = "Total amount of hours worked by this person"
+    label = "Hours worked per week"
     definition_period = YEAR
     unit = "hour"


### PR DESCRIPTION
## Summary
- Updates the `hours_worked` variable label from "Total amount of hours worked by this person" to "Hours worked per week"
- The variable represents weekly hours (divided by `WEEKS_IN_YEAR` for `weekly_hours`, multiplied by 52 for annual wage calculations)

Fixes #451

## Test plan
- [ ] Verify label appears correctly in the PolicyEngine app

🤖 Generated with [Claude Code](https://claude.com/claude-code)