### PR TITLE
Fix description on non-residential SDLT rate parameter

### DIFF
--- a/changelog.d/634.md
+++ b/changelog.d/634.md
@@ -1,0 +1,1 @@
+- Fix incorrect description on non-residential SDLT rate parameter (was labelled "residential")

--- a/policyengine_uk/parameters/gov/hmrc/stamp_duty/non_residential/purchase.yaml
+++ b/policyengine_uk/parameters/gov/hmrc/stamp_duty/non_residential/purchase.yaml
@@ -19,7 +19,7 @@ brackets:
   threshold:
     2003-07-10: 500000
     2016-09-15: null
-description: Stamp Duty Land Tax progressive rates for residential property transfers
+description: Stamp Duty Land Tax progressive rates for non-residential property transfers
 metadata:
   economy: false
   label: Stamp Duty on non-residential property


### PR DESCRIPTION
## Summary
- Fixes the description on `gov/hmrc/stamp_duty/non_residential/purchase.yaml` which incorrectly said "residential property transfers" instead of "non-residential property transfers"

Fixes #634

## Test plan
- [ ] Verify the corrected description displays properly in the app

🤖 Generated with [Claude Code](https://claude.com/claude-code)