### PR TITLE
Remove microdf-python dep redundant with policyengine-core

### DIFF
--- a/changelog.d/920.md
+++ b/changelog.d/920.md
@@ -1,0 +1,1 @@
+- Remove `microdf-python` dependency that is already provided by `policyengine-core`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,6 @@ classifiers = [
 requires-python = ">=3.11"
 dependencies = [
     "policyengine-core>=3.23.6",
-    "microdf-python>=1.2.1",
     "pydantic>=2.11.7",
     "tables>=3.10.2",
 ]


### PR DESCRIPTION
## Summary
- Removes `microdf-python` from `pyproject.toml` dependencies since it's already a dependency of `policyengine-core`

Fixes #920

## Test plan
- [ ] `pip install -e ".[dev]"` still installs successfully
- [ ] `import microdf` still works (provided transitively by policyengine-core)
- [ ] Run test suite to confirm no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)