### PR TITLE
Restructure minimum wage as age-based scale parameter

### DIFF
--- a/changelog.d/1015.md
+++ b/changelog.d/1015.md
@@ -1,0 +1,1 @@
+- Restructure minimum wage parameter into apprentice and non-apprentice (age-based scale) files

--- a/policyengine_uk/parameters/gov/hmrc/minimum_wage/apprentice.yaml
+++ b/policyengine_uk/parameters/gov/hmrc/minimum_wage/apprentice.yaml
@@ -1,0 +1,31 @@
+description: Minimum wage rate for apprentices
+values:
+  2012-10-01: 2.65
+  2013-10-01: 2.68
+  2014-10-01: 2.73
+  2015-10-01: 3.3
+  2016-10-01: 3.4
+  2017-04-01: 3.5
+  2018-04-01: 3.7
+  2019-04-01: 3.9
+  2020-04-01: 4.15
+  2021-04-01: 4.3
+  2022-04-01: 4.81
+  2024-04-01:
+    value: 6.4
+    reference:
+      - title: The National Minimum Wage (Amendment) (No. 2) Regulations 2024
+        href: https://www.legislation.gov.uk/uksi/2024/432/made
+  2025-04-01:
+    value: 7.55
+    reference:
+      - title: The National Minimum Wage (Amendment) Regulations 2025
+        href: https://www.legislation.gov.uk/uksi/2025/401/made
+metadata:
+  economy: false
+  household: false
+  label: Apprentice minimum wage
+  unit: currency-GBP
+  reference:
+  - href: https://www.gov.uk/national-minimum-wage-rates
+    title: GOV.UK - National Minimum Wage

--- a/policyengine_uk/parameters/gov/hmrc/minimum_wage/non_apprentice.yaml
+++ b/policyengine_uk/parameters/gov/hmrc/minimum_wage/non_apprentice.yaml
@@ -1,15 +1,19 @@
-APPRENTICE:
-  values:
-    2012-10-01: 2.65
-    2013-10-01: 2.68
-    2014-10-01: 2.73
-    2015-10-01: 3.3
-    2016-10-01: 3.4
-    2017-04-01: 3.5
-    2018-04-01: 3.7
-    2019-04-01: 3.9
-    2020-04-01: 4.15
-    2021-04-01: 4.3
+description: Minimum wage rate for non-apprentices by age
+
+brackets:
+- threshold:
+    2012-10-01: 0
+  amount:
+    2012-10-01: 3.68
+    2013-10-01: 3.72
+    2014-10-01: 3.79
+    2015-10-01: 3.87
+    2016-10-01: 4.0
+    2017-04-01: 4.05
+    2018-04-01: 4.2
+    2019-04-01: 4.35
+    2020-04-01: 4.55
+    2021-04-01: 4.62
     2022-04-01: 4.81
     2024-04-01:
       value: 6.4
@@ -21,8 +25,9 @@ APPRENTICE:
       reference:
         - title: The National Minimum Wage (Amendment) Regulations 2025
           href: https://www.legislation.gov.uk/uksi/2025/401/made
-BETWEEN_18_20:
-  values:
+- threshold:
+    2012-10-01: 18
+  amount:
     2012-10-01: 4.98
     2013-10-01: 5.03
     2014-10-01: 5.13
@@ -44,8 +49,9 @@ BETWEEN_18_20:
       reference:
         - title: The National Minimum Wage (Amendment) Regulations 2025
           href: https://www.legislation.gov.uk/uksi/2025/401/made
-BETWEEN_21_22:
-  values:
+- threshold:
+    2012-10-01: 21
+  amount:
     2012-10-01: 6.19
     2013-10-01: 6.31
     2014-10-01: 6.5
@@ -68,8 +74,9 @@ BETWEEN_21_22:
       reference:
         - title: The National Minimum Wage (Amendment) Regulations 2025
           href: https://www.legislation.gov.uk/uksi/2025/401/made
-BETWEEN_23_24:
-  values:
+- threshold:
+    2012-10-01: 23
+  amount:
     2012-10-01: 6.19
     2013-10-01: 6.31
     2014-10-01: 6.5
@@ -91,8 +98,9 @@ BETWEEN_23_24:
       reference:
         - title: The National Minimum Wage (Amendment) Regulations 2025
           href: https://www.legislation.gov.uk/uksi/2025/401/made
-OVER_24:
-  values:
+- threshold:
+    2012-10-01: 25
+  amount:
     2012-10-01: 6.19
     2013-10-01: 6.31
     2014-10-01: 6.5
@@ -114,36 +122,15 @@ OVER_24:
       reference:
         - title: The National Minimum Wage (Amendment) Regulations 2025
           href: https://www.legislation.gov.uk/uksi/2025/401/made
-UNDER_18:
-  values:
-    2012-10-01: 3.68
-    2013-10-01: 3.72
-    2014-10-01: 3.79
-    2015-10-01: 3.87
-    2016-10-01: 4.0
-    2017-04-01: 4.05
-    2018-04-01: 4.2
-    2019-04-01: 4.35
-    2020-04-01: 4.55
-    2021-04-01: 4.62
-    2022-04-01: 4.81
-    2024-04-01:
-      value: 6.4
-      reference:
-        - title: The National Minimum Wage (Amendment) (No. 2) Regulations 2024
-          href: https://www.legislation.gov.uk/uksi/2024/432/made
-    2025-04-01:
-      value: 7.55
-      reference:
-        - title: The National Minimum Wage (Amendment) Regulations 2025
-          href: https://www.legislation.gov.uk/uksi/2025/401/made
-description: Minimum wage by age group
+
 metadata:
+  amount_unit: currency-GBP
   economy: false
   household: false
-  label: Minimum wage
+  label: Non-apprentice minimum wage
   propagate_metadata_to_children: true
+  threshold_unit: year
+  type: single_amount
   reference:
   - href: https://www.gov.uk/national-minimum-wage-rates
     title: GOV.UK - National Minimum Wage
-  unit: currency-GBP

--- a/policyengine_uk/tests/policy/baseline/finance/income/minimum_wage.yaml
+++ b/policyengine_uk/tests/policy/baseline/finance/income/minimum_wage.yaml
@@ -5,3 +5,35 @@
     age: 30
   output:
     minimum_wage: 8.91
+
+- name: Minimum wage for a person aged 18 uses the 18 to 20 bracket
+  period: 2025
+  absolute_error_margin: 0
+  input:
+    age: 18
+  output:
+    minimum_wage: 10
+
+- name: Minimum wage for a person aged 21 uses the 21 to 22 bracket
+  period: 2025
+  absolute_error_margin: 0
+  input:
+    age: 21
+  output:
+    minimum_wage: 12.21
+
+- name: Minimum wage for a person aged 23 uses the 23 to 24 bracket
+  period: 2025
+  absolute_error_margin: 0
+  input:
+    age: 23
+  output:
+    minimum_wage: 12.21
+
+- name: Minimum wage for a person aged 25 uses the 25 or over bracket
+  period: 2021
+  absolute_error_margin: 0
+  input:
+    age: 25
+  output:
+    minimum_wage: 8.91

--- a/policyengine_uk/variables/household/income/minimum_wage.py
+++ b/policyengine_uk/variables/household/income/minimum_wage.py
@@ -17,5 +17,5 @@ class minimum_wage(Variable):
         return where(
             is_apprentice,
             MW.apprentice,
-            MW.non_apprentice.calc(age, right=True),
+            MW.non_apprentice.calc(age),
         )

--- a/policyengine_uk/variables/household/income/minimum_wage.py
+++ b/policyengine_uk/variables/household/income/minimum_wage.py
@@ -12,4 +12,10 @@ class minimum_wage(Variable):
 
     def formula(person, period, parameters):
         MW = parameters(period).gov.hmrc.minimum_wage
-        return MW[person("minimum_wage_category", period)]
+        is_apprentice = person("is_apprentice", period)
+        age = person("age", period)
+        return where(
+            is_apprentice,
+            MW.apprentice,
+            MW.non_apprentice.calc(age, right=True),
+        )


### PR DESCRIPTION
## Summary
- Splits `minimum_wage.yaml` into `minimum_wage/apprentice.yaml` (scalar) and `minimum_wage/non_apprentice.yaml` (age-based `single_amount` scale parameter)
- Updates the `minimum_wage` variable formula to look up the rate by age instead of enum category indexing
- All existing rates preserved exactly; verified against known values

Fixes #1015

## Test plan
- [x] Verified age 30 @ 2025 = £12.21, age 30 @ 2021 = £8.91, age 19 @ 2025 = £10.00, apprentice @ 2025 = £7.55
- [ ] Run full test suite to confirm no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)