### PR TITLE
Clarify variable descriptions for self-employment income and corporate wealth

### DIFF
--- a/changelog.d/651.md
+++ b/changelog.d/651.md
@@ -1,0 +1,1 @@
+- Clarify variable descriptions for self-employment income and corporate wealth

--- a/policyengine_uk/variables/input/corporate_wealth.py
+++ b/policyengine_uk/variables/input/corporate_wealth.py
@@ -3,7 +3,7 @@ from policyengine_uk.model_api import *
 
 class corporate_wealth(Variable):
     label = "corporate wealth"
-    documentation = "Total owned wealth in corporations"
+    documentation = "Total owned wealth in corporations, including stocks, mutual funds, private pensions, and corporate bonds"
     entity = Household
     definition_period = YEAR
     value_type = float

--- a/policyengine_uk/variables/input/self_employment_income.py
+++ b/policyengine_uk/variables/input/self_employment_income.py
@@ -5,7 +5,7 @@ class self_employment_income(Variable):
     value_type = float
     entity = Person
     label = "self-employment income"
-    documentation = "Income from self-employment profits. This should be net of self-employment expenses."
+    documentation = "Income from self-employment profits, including gig work. This should be net of self-employment expenses."
     definition_period = YEAR
     unit = GBP
     reference = "Income Tax (Trading and Other Income) Act 2005 s. 1(1)(a)"


### PR DESCRIPTION
## Summary
- Add "including gig work" to `self_employment_income` documentation
- List asset types (stocks, mutual funds, private pensions, corporate bonds) in `corporate_wealth` documentation

Fixes #651

## Test plan
- [ ] Verify descriptions appear correctly in the PolicyEngine app

🤖 Generated with [Claude Code](https://claude.com/claude-code)