### PR TITLE
Add Scottish Carer Support Payment

### DIFF
--- a/changelog.d/950.md
+++ b/changelog.d/950.md
@@ -1,0 +1,1 @@
+- Add Scottish Carer Support Payment, replacing Carer's Allowance for Scottish residents

--- a/policyengine_uk/parameters/gov/social_security_scotland/carer_support_payment/min_hours.yaml
+++ b/policyengine_uk/parameters/gov/social_security_scotland/carer_support_payment/min_hours.yaml
@@ -1,0 +1,11 @@
+description: Minimum number of hours spent providing care to qualify for Carer Support Payment.
+values:
+  2024-11-01: 35
+metadata:
+  economy: false
+  period: week
+  unit: hour
+  label: Carer Support Payment minimum hours
+  reference:
+    - title: Carer Support Payment eligibility
+      href: https://www.mygov.scot/carer-support-payment/eligibility

--- a/policyengine_uk/parameters/gov/social_security_scotland/carer_support_payment/rate.yaml
+++ b/policyengine_uk/parameters/gov/social_security_scotland/carer_support_payment/rate.yaml
@@ -1,0 +1,13 @@
+description: Weekly rate of Carer Support Payment.
+values:
+  2024-11-01: 81.9
+  2025-04-01: 83.29
+  2026-04-01: 86.45
+metadata:
+  period: week
+  unit: currency-GBP
+  label: Carer Support Payment rate
+  uprating: gov.benefit_uprating_cpi
+  reference:
+    - title: Carer Support Payment - mygov.scot
+      href: https://www.mygov.scot/carer-support-payment

--- a/policyengine_uk/parameters/gov/social_security_scotland/carer_support_payment/supplement.yaml
+++ b/policyengine_uk/parameters/gov/social_security_scotland/carer_support_payment/supplement.yaml
@@ -1,0 +1,11 @@
+description: Weekly rate of the Scottish Carer Supplement, paid on top of the Carer Support Payment.
+values:
+  2024-11-01: 0
+  2026-03-01: 11.70
+metadata:
+  period: week
+  unit: currency-GBP
+  label: Scottish Carer Supplement rate
+  reference:
+    - title: New rates for carer and disability payments in 2026
+      href: https://www.socialsecurity.gov.scot/news-events/news/new-payment-rates-from-april-2026

--- a/policyengine_uk/tests/policy/baseline/finance/benefit/personal/carer_support_payment.yaml
+++ b/policyengine_uk/tests/policy/baseline/finance/benefit/personal/carer_support_payment.yaml
@@ -1,0 +1,59 @@
+- name: Carer in Scotland receives CSP, not CA
+  period: 2025
+  input:
+    people:
+      carer:
+        age: 35
+        care_hours: 40
+    benunits:
+      benunit:
+        members: [carer]
+    households:
+      household:
+        members: [carer]
+        country: SCOTLAND
+  output:
+    carer_support_payment:
+      carer: 4331.08
+    carers_allowance:
+      carer: 0
+
+- name: Carer in England receives CA, not CSP
+  period: 2025
+  input:
+    people:
+      carer:
+        age: 35
+        care_hours: 40
+    benunits:
+      benunit:
+        members: [carer]
+    households:
+      household:
+        members: [carer]
+        country: ENGLAND
+  output:
+    carer_support_payment:
+      carer: 0
+    carers_allowance:
+      carer: 4331.08
+
+- name: Non-carer in Scotland gets neither
+  period: 2025
+  input:
+    people:
+      person:
+        age: 35
+        care_hours: 10
+    benunits:
+      benunit:
+        members: [person]
+    households:
+      household:
+        members: [person]
+        country: SCOTLAND
+  output:
+    carer_support_payment:
+      person: 0
+    carers_allowance:
+      person: 0

--- a/policyengine_uk/tests/policy/baseline/finance/benefit/personal/carer_support_payment.yaml
+++ b/policyengine_uk/tests/policy/baseline/finance/benefit/personal/carer_support_payment.yaml
@@ -1,59 +1,32 @@
-- name: Carer in Scotland receives CSP, not CA
+- name: Carer in Scotland receives CSP
   period: 2025
+  absolute_error_margin: 0.01
   input:
-    people:
-      carer:
-        age: 35
-        care_hours: 40
-    benunits:
-      benunit:
-        members: [carer]
-    households:
-      household:
-        members: [carer]
-        country: SCOTLAND
+    age: 35
+    care_hours: 40
+    country: SCOTLAND
   output:
-    carer_support_payment:
-      carer: 4331.08
-    carers_allowance:
-      carer: 0
+    carer_support_payment: 4331.08
+    carers_allowance: 0
 
-- name: Carer in England receives CA, not CSP
+- name: Carer in England receives CA not CSP
   period: 2025
+  absolute_error_margin: 0.01
   input:
-    people:
-      carer:
-        age: 35
-        care_hours: 40
-    benunits:
-      benunit:
-        members: [carer]
-    households:
-      household:
-        members: [carer]
-        country: ENGLAND
+    age: 35
+    care_hours: 40
+    country: ENGLAND
   output:
-    carer_support_payment:
-      carer: 0
-    carers_allowance:
-      carer: 4331.08
+    carer_support_payment: 0
+    carers_allowance: 4331.08
 
 - name: Non-carer in Scotland gets neither
   period: 2025
+  absolute_error_margin: 0
   input:
-    people:
-      person:
-        age: 35
-        care_hours: 10
-    benunits:
-      benunit:
-        members: [person]
-    households:
-      household:
-        members: [person]
-        country: SCOTLAND
+    age: 35
+    care_hours: 10
+    country: SCOTLAND
   output:
-    carer_support_payment:
-      person: 0
-    carers_allowance:
-      person: 0
+    carer_support_payment: 0
+    carers_allowance: 0

--- a/policyengine_uk/tests/test_carer_support_payment.py
+++ b/policyengine_uk/tests/test_carer_support_payment.py
@@ -1,0 +1,78 @@
+from policyengine_uk import Simulation
+
+
+YEAR_2024 = 2024
+YEAR_2025 = 2025
+
+
+def _situation(year: int, **person_overrides):
+    person = {
+        "age": {year: 35},
+        "care_hours": {year: 40},
+    }
+    person.update(person_overrides)
+    return {
+        "people": {
+            "person": person,
+        },
+        "benunits": {
+            "benunit": {
+                "members": ["person"],
+            }
+        },
+        "households": {
+            "household": {
+                "members": ["person"],
+                "country": {year: "SCOTLAND"},
+            }
+        },
+    }
+
+
+def test_scottish_carers_allowance_remains_in_place_for_2024():
+    sim = Simulation(situation=_situation(YEAR_2024))
+
+    assert sim.calculate("carers_allowance", YEAR_2024)[0] > 0
+    assert sim.calculate("carer_support_payment", YEAR_2024)[0] == 0
+
+
+def test_scottish_carers_move_to_csp_in_2025():
+    sim = Simulation(situation=_situation(YEAR_2025))
+
+    assert sim.calculate("carers_allowance", YEAR_2025)[0] == 0
+    assert sim.calculate("carer_support_payment", YEAR_2025)[0] > 0
+
+
+def test_csp_counts_for_pension_credit_carer_additions_and_blocks_severe_disability():
+    sim = Simulation(
+        situation=_situation(
+            YEAR_2025,
+            attendance_allowance={YEAR_2025: 1},
+        )
+    )
+    parameters = sim.tax_benefit_system.parameters(str(YEAR_2025))
+
+    expected_carer_addition = (
+        float(parameters.gov.dwp.pension_credit.guarantee_credit.carer.addition) * 52
+    )
+
+    assert sim.calculate("carer_minimum_guarantee_addition", YEAR_2025)[0] == (
+        expected_carer_addition
+    )
+    assert (
+        sim.calculate("severe_disability_minimum_guarantee_addition", YEAR_2025)[0]
+        == 0
+    )
+
+
+def test_csp_counts_for_uc_non_dep_exemption_and_housing_benefit_income():
+    sim = Simulation(situation=_situation(YEAR_2025))
+
+    csp_amount = sim.calculate("carer_support_payment", YEAR_2025)[0]
+    hb_disregard = sim.calculate("housing_benefit_applicable_income_disregard", YEAR_2025)[
+        0
+    ]
+    hb_income = sim.calculate("housing_benefit_applicable_income", YEAR_2025)[0]
+
+    assert sim.calculate("uc_non_dep_deduction_exempt", YEAR_2025)[0]
+    assert hb_income == max(0, csp_amount - hb_disregard)

--- a/policyengine_uk/tests/test_carer_support_payment.py
+++ b/policyengine_uk/tests/test_carer_support_payment.py
@@ -60,8 +60,7 @@ def test_csp_counts_for_pension_credit_carer_additions_and_blocks_severe_disabil
         expected_carer_addition
     )
     assert (
-        sim.calculate("severe_disability_minimum_guarantee_addition", YEAR_2025)[0]
-        == 0
+        sim.calculate("severe_disability_minimum_guarantee_addition", YEAR_2025)[0] == 0
     )
 
 
@@ -69,9 +68,9 @@ def test_csp_counts_for_uc_non_dep_exemption_and_housing_benefit_income():
     sim = Simulation(situation=_situation(YEAR_2025))
 
     csp_amount = sim.calculate("carer_support_payment", YEAR_2025)[0]
-    hb_disregard = sim.calculate("housing_benefit_applicable_income_disregard", YEAR_2025)[
-        0
-    ]
+    hb_disregard = sim.calculate(
+        "housing_benefit_applicable_income_disregard", YEAR_2025
+    )[0]
     hb_income = sim.calculate("housing_benefit_applicable_income", YEAR_2025)[0]
 
     assert sim.calculate("uc_non_dep_deduction_exempt", YEAR_2025)[0]

--- a/policyengine_uk/variables/contrib/policyengine/pre_budget_change_household_benefits.py
+++ b/policyengine_uk/variables/contrib/policyengine/pre_budget_change_household_benefits.py
@@ -38,6 +38,7 @@ class pre_budget_change_household_benefits(Variable):
         "epg_subsidy",
         "cost_of_living_support_payment",
         "energy_bills_rebate",
+        "carer_support_payment",
     ]
 
     def formula(household, period, parameters):

--- a/policyengine_uk/variables/gov/dwp/carers_allowance.py
+++ b/policyengine_uk/variables/gov/dwp/carers_allowance.py
@@ -9,8 +9,10 @@ class carers_allowance(Variable):
     unit = GBP
 
     def formula(person, period, parameters):
+        in_scotland = person.household("country", period).decode_to_str() == "SCOTLAND"
         receives_ca = person("carers_allowance_reported", period) > 0
         ca = parameters(period).gov.dwp.carers_allowance
         weekly_care_hours = person("care_hours", period)
         meets_work_condition = weekly_care_hours >= ca.min_hours
-        return (meets_work_condition | receives_ca) * ca.rate * WEEKS_IN_YEAR
+        eligible = ~in_scotland & (meets_work_condition | receives_ca)
+        return eligible * ca.rate * WEEKS_IN_YEAR

--- a/policyengine_uk/variables/gov/dwp/carers_allowance.py
+++ b/policyengine_uk/variables/gov/dwp/carers_allowance.py
@@ -10,9 +10,12 @@ class carers_allowance(Variable):
 
     def formula(person, period, parameters):
         in_scotland = person.household("country", period).decode_to_str() == "SCOTLAND"
+        csp_replaces_ca = period.start.year >= 2025
         receives_ca = person("carers_allowance_reported", period) > 0
         ca = parameters(period).gov.dwp.carers_allowance
         weekly_care_hours = person("care_hours", period)
         meets_work_condition = weekly_care_hours >= ca.min_hours
-        eligible = ~in_scotland & (meets_work_condition | receives_ca)
+        eligible = ~(in_scotland & csp_replaces_ca) & (
+            meets_work_condition | receives_ca
+        )
         return eligible * ca.rate * WEEKS_IN_YEAR

--- a/policyengine_uk/variables/gov/dwp/housing_benefit/applicable_income/housing_benefit_applicable_income.py
+++ b/policyengine_uk/variables/gov/dwp/housing_benefit/applicable_income/housing_benefit_applicable_income.py
@@ -18,6 +18,7 @@ class housing_benefit_applicable_income(Variable):
         ]
         PERSONAL_BENEFITS = [
             "carers_allowance",
+            "carer_support_payment",
             "esa_contrib",
             "jsa_contrib",
             "state_pension",

--- a/policyengine_uk/variables/gov/dwp/is_benefit_cap_exempt_health_disability.py
+++ b/policyengine_uk/variables/gov/dwp/is_benefit_cap_exempt_health_disability.py
@@ -36,6 +36,7 @@ class is_benefit_cap_exempt_health_disability(Variable):
         QUAL_PERSONAL_BENEFITS = [
             "attendance_allowance",
             "carers_allowance",
+            "carer_support_payment",
             "dla",  # Disability Living Allowance (includes components)
             "pip_dl",  # PIP daily living component
             "pip_m",  # PIP mobility component

--- a/policyengine_uk/variables/gov/dwp/pension_credit/guarantee_credit/minimum_guarantee/additional/carer_minimum_guarantee_addition.py
+++ b/policyengine_uk/variables/gov/dwp/pension_credit/guarantee_credit/minimum_guarantee/additional/carer_minimum_guarantee_addition.py
@@ -10,7 +10,7 @@ class carer_minimum_guarantee_addition(Variable):
     reference = "https://www.legislation.gov.uk/uksi/2002/1792/schedule/I/paragraph/4"
 
     def formula(benunit, period, parameters):
-        carers_allowance = benunit.members("carers_allowance", period)
-        num_receiving_carers_allowance = benunit.sum(carers_allowance > 0)
+        receives_carer_benefit = benunit.members("receives_carer_benefit", period)
+        num_receiving_carers = benunit.sum(receives_carer_benefit)
         gc = parameters(period).gov.dwp.pension_credit.guarantee_credit
-        return num_receiving_carers_allowance * gc.carer.addition * WEEKS_IN_YEAR
+        return num_receiving_carers * gc.carer.addition * WEEKS_IN_YEAR

--- a/policyengine_uk/variables/gov/dwp/pension_credit/guarantee_credit/minimum_guarantee/additional/severe_disability_minimum_guarantee_addition.py
+++ b/policyengine_uk/variables/gov/dwp/pension_credit/guarantee_credit/minimum_guarantee/additional/severe_disability_minimum_guarantee_addition.py
@@ -26,8 +26,8 @@ class severe_disability_minimum_guarantee_addition(Variable):
         any_children_without_benefits = (
             benunit.sum(~is_adult & ~person_receives_qualifying_benefits) > 0
         )
-        carers_allowance_received = add(benunit, period, ["carers_allowance"]) > 0
-        eligible = ~any_children_without_benefits & ~carers_allowance_received
+        carer_benefit_received = add(benunit, period, ["receives_carer_benefit"]) > 0
+        eligible = ~any_children_without_benefits & ~carer_benefit_received
         return (
             eligible
             * count_eligible_adults

--- a/policyengine_uk/variables/gov/dwp/universal_credit/housing_costs_element/non_dep_deduction/uc_non_dep_deduction_exempt.py
+++ b/policyengine_uk/variables/gov/dwp/universal_credit/housing_costs_element/non_dep_deduction/uc_non_dep_deduction_exempt.py
@@ -13,5 +13,5 @@ class uc_non_dep_deduction_exempt(Variable):
             | person("dla_sc_middle_plus", period)
             | (person("pip_dl", period) > 0)
             | (person("attendance_allowance", period) > 0)
-            | person("receives_carers_allowance", period)
+            | person("receives_carer_benefit", period)
         )

--- a/policyengine_uk/variables/gov/gov_spending.py
+++ b/policyengine_uk/variables/gov/gov_spending.py
@@ -55,4 +55,5 @@ class gov_spending(Variable):
         "dfe_education_spending",
         "dft_subsidy_spending",
         "nhs_spending",
+        "carer_support_payment",
     ]

--- a/policyengine_uk/variables/gov/hmrc/income_tax/social_security_income.py
+++ b/policyengine_uk/variables/gov/hmrc/income_tax/social_security_income.py
@@ -15,4 +15,5 @@ class social_security_income(Variable):
         "jsa_contrib_reported",
         "esa_contrib_reported",
         "carers_allowance",
+        "carer_support_payment",
     ]

--- a/policyengine_uk/variables/gov/social_security_scotland/carer_support_payment.py
+++ b/policyengine_uk/variables/gov/social_security_scotland/carer_support_payment.py
@@ -1,0 +1,27 @@
+from policyengine_uk.model_api import *
+
+
+class carer_support_payment(Variable):
+    value_type = float
+    entity = Person
+    label = "Carer Support Payment"
+    documentation = (
+        "Carer Support Payment replaces Carer's Allowance for "
+        "eligible carers living in Scotland."
+    )
+    definition_period = YEAR
+    unit = GBP
+    reference = [
+        "https://www.mygov.scot/carer-support-payment",
+        "https://www.legislation.gov.uk/asp/2018/9/part/4",
+    ]
+
+    def formula(person, period, parameters):
+        in_scotland = person.household("country", period).decode_to_str() == "SCOTLAND"
+        csp = parameters(period).gov.social_security_scotland.carer_support_payment
+        weekly_care_hours = person("care_hours", period)
+        meets_hours = weekly_care_hours >= csp.min_hours
+        receives_ca = person("carers_allowance_reported", period) > 0
+        eligible = in_scotland & (meets_hours | receives_ca)
+        weekly_amount = csp.rate + csp.supplement
+        return eligible * weekly_amount * WEEKS_IN_YEAR

--- a/policyengine_uk/variables/gov/social_security_scotland/carer_support_payment.py
+++ b/policyengine_uk/variables/gov/social_security_scotland/carer_support_payment.py
@@ -18,10 +18,11 @@ class carer_support_payment(Variable):
 
     def formula(person, period, parameters):
         in_scotland = person.household("country", period).decode_to_str() == "SCOTLAND"
+        csp_in_effect = period.start.year >= 2025
         csp = parameters(period).gov.social_security_scotland.carer_support_payment
         weekly_care_hours = person("care_hours", period)
         meets_hours = weekly_care_hours >= csp.min_hours
         receives_ca = person("carers_allowance_reported", period) > 0
-        eligible = in_scotland & (meets_hours | receives_ca)
+        eligible = in_scotland & csp_in_effect & (meets_hours | receives_ca)
         weekly_amount = csp.rate + csp.supplement
         return eligible * weekly_amount * WEEKS_IN_YEAR

--- a/policyengine_uk/variables/household/demographic/is_carer_for_benefits.py
+++ b/policyengine_uk/variables/household/demographic/is_carer_for_benefits.py
@@ -8,6 +8,4 @@ class is_carer_for_benefits(Variable):
     definition_period = YEAR
 
     def formula(person, period, parameters):
-        return person("receives_carers_allowance", period) | (
-            person("carer_support_payment", period) > 0
-        )
+        return person("receives_carer_benefit", period)

--- a/policyengine_uk/variables/household/demographic/is_carer_for_benefits.py
+++ b/policyengine_uk/variables/household/demographic/is_carer_for_benefits.py
@@ -8,4 +8,6 @@ class is_carer_for_benefits(Variable):
     definition_period = YEAR
 
     def formula(person, period, parameters):
-        return person("receives_carers_allowance", period)
+        return person("receives_carers_allowance", period) | (
+            person("carer_support_payment", period) > 0
+        )

--- a/policyengine_uk/variables/household/income/hbai_benefits.py
+++ b/policyengine_uk/variables/household/income/hbai_benefits.py
@@ -43,4 +43,5 @@ class hbai_benefits(Variable):
         "disabled_students_allowance",
         "bursary_fund_16_to_19",
         "healthy_start_vouchers",
+        "carer_support_payment",
     ]

--- a/policyengine_uk/variables/household/income/hbai_household_net_income.py
+++ b/policyengine_uk/variables/household/income/hbai_household_net_income.py
@@ -55,6 +55,7 @@ class hbai_household_net_income(Variable):
         "tax_free_childcare",
         "healthy_start_vouchers",
         "scottish_child_payment",
+        "carer_support_payment",
         # Reference for tax-free-childcare: https://assets.publishing.service.gov.uk/media/5e7b191886650c744175d08b/households-below-average-income-1994-1995-2018-2019.pdf
     ]
     subtracts = [

--- a/policyengine_uk/variables/household/income/household_benefits.py
+++ b/policyengine_uk/variables/household/income/household_benefits.py
@@ -57,6 +57,7 @@ class household_benefits(Variable):
         "healthy_start_vouchers",
         "two_child_limit_payment",
         "scottish_child_payment",
+        "carer_support_payment",
     ]
 
     def formula(household, period, parameters):

--- a/policyengine_uk/variables/input/care.py
+++ b/policyengine_uk/variables/input/care.py
@@ -12,3 +12,30 @@ class receives_carers_allowance(Variable):
 
     def formula(person, period, parameters):
         return person("carers_allowance", period) > 0
+
+
+class receives_carer_support_payment(Variable):
+    value_type = bool
+    entity = Person
+    label = "receives Carer Support Payment"
+    documentation = "Whether this person receives Carer Support Payment."
+    definition_period = YEAR
+
+    def formula(person, period, parameters):
+        return person("carer_support_payment", period) > 0
+
+
+class receives_carer_benefit(Variable):
+    value_type = bool
+    entity = Person
+    label = "receives a carer benefit"
+    documentation = (
+        "Whether this person receives Carer's Allowance or the Scottish "
+        "Carer Support Payment."
+    )
+    definition_period = YEAR
+
+    def formula(person, period, parameters):
+        return person("receives_carers_allowance", period) | person(
+            "receives_carer_support_payment", period
+        )


### PR DESCRIPTION
## Summary
- Implements Carer Support Payment (CSP), which replaced Carer's Allowance for carers living in Scotland (fully rolled out November 2024)
- CSP parameters: weekly rate (£83.29 in 2025, £86.45 in 2026), Scottish Carer Supplement (£11.70/week from March 2026), and 35-hour minimum care threshold
- Scottish residents now receive CSP instead of Carer's Allowance
- CSP added to all benefit aggregation lists (household_benefits, hbai_benefits, hbai_household_net_income, gov_spending, social_security_income, pre_budget_change_household_benefits)
- `is_carer_for_benefits` updated to recognise CSP recipients

Fixes #950

## Test plan
- [x] Scotland carer (35+ hours) gets CSP £4,331.08/yr, CA £0
- [x] England carer gets CA £4,331.08/yr, CSP £0
- [x] Non-carer in Scotland gets neither
- [x] 2026 Scotland carer gets CSP with supplement £5,103.80/yr
- [ ] CI test suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)