### PR TITLE
Add microsimulation smoke test against unpinned latest data

### DIFF
--- a/changelog.d/latest-data-smoke.added.md
+++ b/changelog.d/latest-data-smoke.added.md
@@ -1,0 +1,1 @@
+- Add a microsimulation smoke test suite that runs against the unpinned latest enhanced FRS dataset and asserts plausibility bounds for UK population, UC aggregate, `is_parent` population, core benefit totals, and extended childcare eligibility. Catches silent model/data skew at the point the dataset is republished, not after a release.

--- a/policyengine_uk/tests/test_latest_data_smoke.py
+++ b/policyengine_uk/tests/test_latest_data_smoke.py
@@ -1,0 +1,129 @@
+"""Smoke tests against the *latest* published enhanced FRS dataset.
+
+These complement the pinned microsimulation tests in
+``policyengine_uk/tests/microsimulation/`` by exercising the model against
+whatever is currently on HuggingFace `main`, so that a silent break at the
+model/data boundary (e.g. the model expecting an input column the rebuilt
+dataset hasn't populated) shows up in CI rather than after a release.
+
+Bounds are deliberately wide — they catch catastrophic failures (e.g.
+``is_parent`` defaulting to zero, UC aggregate collapsing by ~£25 bn) without
+tripping on normal calibration noise.
+
+Skipped unless ``HUGGING_FACE_TOKEN`` or ``POLICYENGINE_UK_DEFAULT_DATASET`` is
+set, via the ``microsimulation`` marker configured in ``conftest.py``.
+"""
+
+from __future__ import annotations
+
+import os
+
+import numpy as np
+import pytest
+
+from policyengine_uk import Microsimulation
+
+
+LATEST_DATASET_URL = (
+    "hf://policyengine/policyengine-uk-data-private/enhanced_frs_2023_24.h5"
+)
+YEAR = 2025
+
+
+@pytest.fixture(scope="module")
+def sim() -> Microsimulation:
+    """Simulation built against the unpinned latest dataset.
+
+    Overrides any pinned-version dataset set in conftest.py so the test
+    exercises whatever is on HuggingFace ``main`` right now.
+    """
+    os.environ["POLICYENGINE_UK_DEFAULT_DATASET"] = LATEST_DATASET_URL
+    return Microsimulation()
+
+
+def _weighted(sim: Microsimulation, variable: str, period: int = YEAR) -> float:
+    values = np.asarray(sim.calculate(variable, period).values, dtype=float)
+    n = len(values)
+    for weight_var in ("person_weight", "benunit_weight", "household_weight"):
+        weight = np.asarray(sim.calculate(weight_var, period).values, dtype=float)
+        if len(weight) == n:
+            return float((values * weight).sum())
+    raise AssertionError(
+        f"No entity weight matches length {n} for variable {variable!r}"
+    )
+
+
+@pytest.mark.microsimulation
+def test_population_totals_are_plausible(sim):
+    """UK weighted population and household counts sit in sensible bounds."""
+    people = float(np.asarray(sim.calculate("person_weight", YEAR).values).sum())
+    benunits = float(np.asarray(sim.calculate("benunit_weight", YEAR).values).sum())
+    households = float(np.asarray(sim.calculate("household_weight", YEAR).values).sum())
+
+    # ONS mid-2024 estimate ~68.9M; OBR forecasts 2025 ≈ 69.5M.
+    assert 65e6 < people < 75e6, f"People total {people:.3g} outside 65-75M"
+    # FRS implies ~33-35M benefit units; ONS ~28M households.
+    assert 30e6 < benunits < 38e6, f"Benefit units total {benunits:.3g} outside 30-38M"
+    assert 26e6 < households < 34e6, f"Household total {households:.3g} outside 26-34M"
+
+
+@pytest.mark.microsimulation
+def test_is_parent_is_populated(sim):
+    """``is_parent`` must come from FRS microdata, not default to zero.
+
+    Catches the PolicyEngine/policyengine-uk#1595 failure mode where the
+    inferred-formula was removed but a rebuilt dataset hadn't yet populated
+    the column.
+    """
+    parents = _weighted(sim, "is_parent")
+    # UK has ~15M parents of dependent children — anything under a few
+    # million indicates the column defaulted rather than loaded.
+    assert parents > 10e6, (
+        f"is_parent weighted total {parents:.3g} is too low — the variable "
+        "is likely defaulting to zero because the input column is missing."
+    )
+
+
+@pytest.mark.microsimulation
+def test_universal_credit_aggregate_in_range(sim):
+    """UC aggregate sits within plausible range of the OBR forecast.
+
+    Catches cases where capital-limit or other model logic interacts
+    badly with the data (e.g. stale savings imputations producing
+    sub-£60bn UC aggregates when the target is ~£74bn).
+    """
+    uc = _weighted(sim, "universal_credit")
+    # OBR Nov 2025 EFO calibration target is ~£74bn. Bounds allow for
+    # +/-25% drift either side before failing.
+    assert 55e9 < uc < 95e9, (
+        f"Universal credit aggregate £{uc / 1e9:.1f}bn outside "
+        "£55-£95bn plausibility range"
+    )
+
+
+@pytest.mark.microsimulation
+def test_core_benefits_are_nonzero(sim):
+    """Core benefit aggregates must produce output, not collapse to zero."""
+    for variable, lower in [
+        ("state_pension", 100e9),
+        ("child_benefit", 10e9),
+        ("pension_credit", 2e9),
+    ]:
+        total = _weighted(sim, variable)
+        assert total > lower, (
+            f"{variable} aggregate £{total / 1e9:.2g}bn below £{lower / 1e9:.0f}bn floor"
+        )
+
+
+@pytest.mark.microsimulation
+def test_childcare_entitlement_populated(sim):
+    """Extended childcare entitlement must reach >0 benefit units.
+
+    Catches the downstream failure when ``is_parent`` is defaulted —
+    every childcare-eligibility chain collapses to zero.
+    """
+    eligible = _weighted(sim, "extended_childcare_entitlement_eligible")
+    assert eligible > 500_000, (
+        f"extended_childcare_entitlement_eligible weighted total "
+        f"{eligible:.3g} implies the childcare chain is broken"
+    )


### PR DESCRIPTION
## Summary

Catches silent model/data skew at the point the enhanced FRS dataset is republished on HuggingFace, not after a release. Exercises whatever is currently on HF `main` (unlike `conftest.py` which pins to an older version) and asserts plausibility bounds on:

- UK weighted population and household/benunit counts
- `is_parent` weighted population (>10M) — catches the defaulting-to-zero failure introduced by removing the inferred formula in #1595
- Universal credit aggregate in £55–£95bn range around the OBR target
- State pension / child benefit / pension credit floors
- `extended_childcare_entitlement_eligible` reaching >500k benefit units

## Why

Between 2026-04-15 14:04 UTC (when #1595 removed the inferred `is_parent` formula) and 2026-04-16 14:17 UTC (when uk-data 1.50.3 published an FRS build with an `is_parent` column), any run of `policyengine-uk` main against the prior dataset silently produced:

- `is_parent = 0` everywhere
- `extended_childcare_entitlement_eligible = 0` everywhere
- Universal credit aggregate ≈ £51.7bn (vs OBR target ~£74bn), because capital-limit logic combined with stale savings imputations over-triggered disqualifications

None of that surfaced in CI because the existing `microsimulation`-marked tests pin to dataset version `1.40.3` via `conftest.py`. This adds a parallel, unpinned test that uses whatever is on HF `main` — so the next time model code and data pipelines drift apart, CI notices.

## Verification

Local run against fresh 1.50.3: all 5 tests pass.

Local run against the stale 1.45.8 snapshot from before the fix:

```
PASS: test_population_totals_are_plausible
FAIL: test_is_parent_is_populated — is_parent weighted total 0 is too low
FAIL: test_universal_credit_aggregate_in_range — UC £51.7bn outside £55–£95bn
PASS: test_core_benefits_are_nonzero
FAIL: test_childcare_entitlement_populated — extended_childcare_entitlement_eligible total 0
```

i.e. the three failure modes the April 15–16 window actually exhibited all trip.

## Scope

- `policyengine_uk/tests/test_latest_data_smoke.py` — 5 new tests, all marked `microsimulation` so they skip unless `HUGGING_FACE_TOKEN` is present.
- `changelog.d/latest-data-smoke.added.md` — changelog fragment.
- No production code touched.

## Test plan

- [x] `uvx ruff format --check` / `uvx ruff check` clean
- [x] All 5 tests pass locally against fresh HF `main` (1.50.3)
- [x] 3 of 5 tests fail as expected against stale 1.45.8 snapshot
- [ ] CI `Test` job passes
