### PR TITLE
Add Ofgem Q2 2026 energy price cap of £1,641

### DIFF
--- a/changelog.d/1616.md
+++ b/changelog.d/1616.md
@@ -1,0 +1,1 @@
+- Add Ofgem Q2 2026 (April–June 2026) energy price cap of £1,641.

--- a/policyengine_uk/parameters/gov/ofgem/energy_price_cap.yaml
+++ b/policyengine_uk/parameters/gov/ofgem/energy_price_cap.yaml
@@ -15,6 +15,7 @@ values:
   2023-10-01: 2_389
   2025-04-01: 1_849
   2025-07-01: 1_720
+  2026-04-01: 1_641
 metadata:
   unit: currency-GBP
   period: year


### PR DESCRIPTION
## Summary
- Adds `2026-04-01: 1_641` to `gov.ofgem.energy_price_cap` so that 2026+ simulations pick up the confirmed Q2 2026 cap instead of extrapolating the previous £1,720 entry.
- Fixes #1616.

## Context
`policyengine_uk/parameters/gov/ofgem/energy_price_cap.yaml` previously stopped at `2025-07-01: 1_720`, so `pe.gov.ofgem.energy_price_cap("2026-04-01")` returned £1,720 (auto-extrapolated) instead of Ofgem's confirmed Q2 2026 figure of £1,641.

Source: [Ofgem — Energy price cap explained](https://www.ofgem.gov.uk/information-consumers/energy-advice-households/energy-price-cap-explained)

## Out of scope
The issue also notes that electricity/gas unit rates (24.70p/kWh electricity, 5.70p/kWh gas for Q2 2026) are not exposed as parameters. That's a separate change — new parameters plus downstream usage — and belongs in its own PR.

## Test plan
- [ ] `pe.gov.ofgem.energy_price_cap("2026-04-01")` returns `1641`.
- [ ] Existing energy-cap-dependent tests still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)