### PR TITLE
Add childcare eligibility question inputs

### DIFF
--- a/changelog.d/1005.md
+++ b/changelog.d/1005.md
@@ -1,0 +1,1 @@
+- Add `is_about_to_start_paid_work` and `is_newly_self_employed` as Person-level boolean input variables so front-ends can prompt users about childcare-program eligibility scenarios that existing variables do not surface generically.

--- a/policyengine_uk/variables/input/childcare_eligibility_questions.py
+++ b/policyengine_uk/variables/input/childcare_eligibility_questions.py
@@ -1,0 +1,34 @@
+from policyengine_uk.model_api import *
+
+
+class is_about_to_start_paid_work(Variable):
+    value_type = bool
+    entity = Person
+    label = "about to start paid work"
+    documentation = (
+        "Whether this person is about to start paid work. Some childcare "
+        "support programs (e.g. Tax-Free Childcare under SI 2015/448) treat "
+        "imminent starters as in qualifying paid work for eligibility "
+        "purposes. Captured as an input so front-ends can prompt users and "
+        "future program formulas can consume it."
+    )
+    definition_period = YEAR
+    default_value = False
+
+
+class is_newly_self_employed(Variable):
+    value_type = bool
+    entity = Person
+    label = "newly self-employed (business under 12 months old)"
+    documentation = (
+        "Whether this person has been self-employed for less than 12 "
+        "months. Several childcare support programs relax income or work "
+        "tests during a self-employment start-up period. For Tax-Free "
+        "Childcare specifically, the more narrowly-scoped "
+        "`tax_free_childcare_self_employment_start_up_period` input is "
+        "what the eligibility formula consumes; this variable exists as a "
+        "general-purpose question for front-ends covering multiple "
+        "childcare programs."
+    )
+    definition_period = YEAR
+    default_value = False


### PR DESCRIPTION
## Summary
- Adds two Person-level boolean input variables that front-ends can ask users about when showing eligibility hints for childcare support programs:
  - `is_about_to_start_paid_work`
  - `is_newly_self_employed`
- Both are pure inputs (`default_value = False`, no formula), per @MaxGhenis's direction in #1005.
- Fixes #1005.

## Why not wire these into TFC eligibility?
Tax-Free Childcare already has the narrower `tax_free_childcare_self_employment_start_up_period` input (reg 11 of SI 2015/448) which feeds `tax_free_childcare_treated_as_in_work` → `tax_free_childcare_work_condition`. The new variables are intentionally **general-purpose companions** for apps prompting users about multiple childcare programs (TFC, universal/targeted entitlement, childcare grant, 15/30 hours, etc.) rather than TFC-specific inputs. Keeping them input-only avoids accidentally changing TFC eligibility semantics while still surfacing the questions at the model layer where the app can discover them.

A follow-up PR could wire them into specific program formulas once the legal/policy mapping for each program is confirmed.

## Test plan
- [ ] `python -c "from policyengine_uk.system import system; system.variables['is_about_to_start_paid_work']; system.variables['is_newly_self_employed']"` imports the TBS without error.
- [ ] Existing TFC YAML baselines unchanged (no formula wiring yet).

🤖 Generated with [Claude Code](https://claude.com/claude-code)