### PR TITLE
Pay couple Carer Premium when a benunit has 3+ carers

### DIFF
--- a/changelog.d/420.md
+++ b/changelog.d/420.md
@@ -1,0 +1,1 @@
+- Pay the two-carer Carer Premium rate when a benefit unit has three or more carers. The previous `carers == 2` condition silently returned £0 for the (rare) case of three or more carers in the same benefit unit; the Carer Premium regulations don't define a higher rate, so the couple rate is the correct ceiling.

--- a/policyengine_uk/tests/policy/baseline/finance/benefit/care.yaml
+++ b/policyengine_uk/tests/policy/baseline/finance/benefit/care.yaml
@@ -7,3 +7,27 @@
     is_carer_for_benefits: true
     num_carers: 1
     carer_premium: 37.5 * 52
+
+- name: Two carers in a benefit unit receive the couple rate
+  period: 2020
+  absolute_error_margin: 0
+  input:
+    num_carers: 2
+  output:
+    carer_premium: 37.5 * 52
+
+- name: Three carers in a benefit unit stay at the couple rate (regression for #420)
+  period: 2020
+  absolute_error_margin: 0
+  input:
+    num_carers: 3
+  output:
+    carer_premium: 37.5 * 52
+
+- name: No carers in a benefit unit receive no premium
+  period: 2020
+  absolute_error_margin: 0
+  input:
+    num_carers: 0
+  output:
+    carer_premium: 0

--- a/policyengine_uk/variables/household/demographic/carer_premium.py
+++ b/policyengine_uk/variables/household/demographic/carer_premium.py
@@ -13,7 +13,7 @@ class carer_premium(Variable):
         carers = benunit("num_carers", period.this_year)
         CP = parameters(period).gov.dwp.carer_premium
         weekly_premium = select(
-            [carers == 0, carers == 1, carers == 2],
-            [0, CP.single, CP.couple],
+            [carers >= 2, carers == 1],
+            [CP.couple, CP.single],
         )
         return weekly_premium * WEEKS_IN_YEAR


### PR DESCRIPTION
## Summary
- Fixes #420.
- The `carer_premium` formula used `select([carers == 0, carers == 1, carers == 2], [0, CP.single, CP.couple])`, so any benefit unit with 3 or more carers silently fell through to numpy's default of `0` — no premium paid despite at least one qualifying carer.
- Rewrites the branch as `select([carers >= 2, carers == 1], [CP.couple, CP.single])`. The Carer Premium regulations don't define a rate higher than the couple rate, so clamping to the couple rate is the correct behaviour for 3+ carers (e.g. a benunit with two adult carers plus a young-carer child meeting `is_carer_for_benefits`).

## Behaviour change
| `num_carers` | Before | After |
|---:|---:|---:|
| 0 | 0 | 0 (unchanged) |
| 1 | `CP.single` | `CP.single` (unchanged) |
| 2 | `CP.couple` | `CP.couple` (unchanged) |
| 3+ | **0** | `CP.couple` |

Only the rare 3+ case changes. `num_carers` is `add(benunit, period, ["is_carer_for_benefits"])`, so this is only reachable when a dependent child in the benefit unit is also flagged as a carer for benefits — uncommon but structurally possible.

## Test plan
- [ ] Existing `carer_premium` YAML baselines still pass (no change for 0/1/2 carers).
- [ ] Add targeted YAML test for 3-carer benunit resolving to couple rate? — left out of this PR to keep the diff surgical; happy to follow up if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)