### PR TITLE
Mint GitHub App token in versioning workflow

### DIFF
--- a/.github/workflows/versioning.yaml
+++ b/.github/workflows/versioning.yaml
@@ -1,6 +1,7 @@
 # Workflow that runs on versioning metadata updates.
 # Uses GITHUB_TOKEN (not a personal PAT) for same-repo operations.
-# Cross-repo API updates require POLICYENGINE_GITHUB secret (org-level PAT).
+# Cross-repo API updates use a GitHub App token minted at runtime from the
+# org-level APP_ID / APP_PRIVATE_KEY secrets.
 
 name: Versioning updates
 on:
@@ -51,6 +52,12 @@ jobs:
     needs: Versioning
     if: needs.Versioning.outputs.committed == 'true'
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
       - name: Checkout repo
         uses: actions/checkout@v4
         with:
@@ -83,7 +90,7 @@ jobs:
           if [ -n "$CROSS_REPO_TOKEN" ]; then
             GITHUB_TOKEN="$CROSS_REPO_TOKEN" python .github/update_api.py
           else
-            echo "Skipping cross-repo API update (POLICYENGINE_GITHUB secret not set)"
+            echo "Skipping cross-repo API update (App token not minted)"
           fi
         env:
-          CROSS_REPO_TOKEN: ${{ secrets.POLICYENGINE_GITHUB }}
+          CROSS_REPO_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/changelog.d/migrate-to-app-token.fixed.md
+++ b/changelog.d/migrate-to-app-token.fixed.md
@@ -1,0 +1,1 @@
+Migrate versioning workflow to GitHub App token (POLICYENGINE_GITHUB PAT expired).


### PR DESCRIPTION
## Summary

The org-level `POLICYENGINE_GITHUB` PAT expired on 2026-01-12. In this repo it is only referenced by `.github/workflows/versioning.yaml`, where the `Publish` job passes it as `CROSS_REPO_TOKEN` to `.github/update_api.py` (which cross-repo-pings `policyengine-api` so the app picks up the newly published package).

With the PAT expired, `CROSS_REPO_TOKEN` resolves to an empty string; the graceful fallback in the workflow logs `Skipping cross-repo API update` and moves on, so the cross-repo ping silently stops firing on every release.

## Fix

Swap the PAT for a short-lived GitHub App token minted via `actions/create-github-app-token@v1`, using the org-level `APP_ID` / `APP_PRIVATE_KEY` secrets already set and used by sibling repos (`policyengine-core` #470, `microdf` #296, `policyengine-us`, `policyengine-api`). Pattern copied from those PRs.

Benefits over renewing the PAT:
- No annual expiry to chase
- Not tied to any one person's account
- Narrower principle-of-least-privilege scope

Scope note: this repo's `Versioning` job already uses the default `GITHUB_TOKEN` (not the PAT) for checkout and `add-and-commit`, and the `Publish` job runs in the same workflow run via `needs: Versioning`, so App-token-triggered downstream workflow runs aren't needed here. Only the `Publish` job changes.

## Test plan

- [x] `yaml.safe_load` confirms the workflow still parses
- [x] `towncrier build --draft` renders the changelog fragment correctly
- [ ] After merge, on the next release: `Publish` job's `Update API` step actually fires `update_api.py` (not the skip branch) and the corresponding dispatch lands in `policyengine-api`

## Caveat

If the GitHub App isn't installed on `policyengine-api`, the `update_api.py` step will fail (rather than silently skip). That would be a separate fix on the App installation side; the checkout + PyPI publish parts are unaffected.