### PR TITLE
Zero out Income Support and income-based JSA after managed migration

### DIFF
--- a/changelog.d/add-income-support-phaseout.fixed.md
+++ b/changelog.d/add-income-support-phaseout.fixed.md
@@ -1,0 +1,1 @@
+Zero out Income Support and income-based Jobseeker's Allowance after DWP managed migration completed on 31 March 2026. New parameters `gov.dwp.income_support.active` and `gov.dwp.JSA.income.active` flip to `false` from 2026-04-01, matching the Tax Credits treatment. Contribution-based JSA remains active.

--- a/policyengine_uk/parameters/gov/dwp/JSA/income/active.yaml
+++ b/policyengine_uk/parameters/gov/dwp/JSA/income/active.yaml
@@ -1,0 +1,14 @@
+description: Whether income-based Jobseeker's Allowance is actively paying awards. Income-based JSA closed to new claims with Universal Credit's rollout, and the remaining legacy caseload was migrated to UC under DWP's managed-migration programme; last payments were made on 31 March 2026. Contribution-based JSA is a separate scheme and remains active.
+values:
+  1996-10-07: true
+  2026-04-01: false
+metadata:
+  label: Income-based JSA scheme active
+  unit: bool
+  reference:
+    - title: "House of Commons Library: Completing Universal Credit rollout (CBP-9984)"
+      href: https://commonslibrary.parliament.uk/research-briefings/cbp-9984/
+    - title: "DWP: Successful DWP campaign leads to closure of historical benefits"
+      href: https://www.gov.uk/government/news/successful-dwp-campaign-leads-to-closure-of-historical-benefits
+    - title: "Jobseekers Act 1995"
+      href: https://www.legislation.gov.uk/ukpga/1995/18/contents

--- a/policyengine_uk/parameters/gov/dwp/income_support/active.yaml
+++ b/policyengine_uk/parameters/gov/dwp/income_support/active.yaml
@@ -1,0 +1,16 @@
+description: Whether Income Support is actively paying awards. Income Support closed to new claims with Universal Credit's rollout, and the remaining legacy caseload was migrated to UC (or to Pension Credit for over-State-Pension-age claimants) under DWP's managed-migration programme; last payments were made on 31 March 2026.
+values:
+  1988-04-11: true
+  2026-04-01: false
+metadata:
+  label: Income Support scheme active
+  unit: bool
+  reference:
+    - title: "House of Commons Library: Completing Universal Credit rollout (CBP-9984)"
+      href: https://commonslibrary.parliament.uk/research-briefings/cbp-9984/
+    - title: "DWP: Successful DWP campaign leads to closure of historical benefits"
+      href: https://www.gov.uk/government/news/successful-dwp-campaign-leads-to-closure-of-historical-benefits
+    - title: "DWP: Move to Universal Credit — insight on Income Support and Housing Benefit"
+      href: https://www.gov.uk/government/publications/move-to-universal-credit-insight-on-income-support-and-housing-benefit-and-initial-esa-cohort-activity/move-to-universal-credit-insight-on-income-support-and-housing-benefit-and-initial-esa-cohort-activity
+    - title: "Social Security Contributions and Benefits Act 1992, Part VII (Income Support)"
+      href: https://www.legislation.gov.uk/ukpga/1992/4/part/VII

--- a/policyengine_uk/tests/policy/baseline/finance/benefit/family/esa_income/esa_income_capital.yaml
+++ b/policyengine_uk/tests/policy/baseline/finance/benefit/family/esa_income/esa_income_capital.yaml
@@ -168,7 +168,7 @@
     esa_income_assessable_capital: [18_000, 18_000]
 
 - name: Income-related ESA capital screening can activate the existing Income Support path
-  period: 2026
+  period: 2025
   absolute_error_margin: 1
   input:
     people:
@@ -190,4 +190,4 @@
   output:
     esa_income: 0
     income_support_eligible: true
-    income_support: 5_430.5776
+    income_support: 5_252.0073

--- a/policyengine_uk/tests/policy/baseline/finance/benefit/family/income_support_post_migration.yaml
+++ b/policyengine_uk/tests/policy/baseline/finance/benefit/family/income_support_post_migration.yaml
@@ -1,0 +1,119 @@
+- name: Income Support still paid in 2025 (scheme active until 31 March 2026)
+  period: 2025
+  absolute_error_margin: 5
+  input:
+    people:
+      p1:
+        age: 26
+        income_support_reported: 3000
+      c1:
+        age: 4
+        is_child: true
+    benunits:
+      b1:
+        members: [p1, c1]
+        would_claim_IS: true
+    households:
+      household:
+        members: [p1, c1]
+        savings: 1000
+  output:
+    income_support: 5252.0073
+
+- name: Income Support is zero after scheme ended on 31 March 2026
+  period: 2026
+  absolute_error_margin: 0
+  input:
+    people:
+      p1:
+        age: 26
+        income_support_reported: 3000
+      c1:
+        age: 4
+        is_child: true
+    benunits:
+      b1:
+        members: [p1, c1]
+        would_claim_IS: true
+    households:
+      household:
+        members: [p1, c1]
+        savings: 1000
+  output:
+    income_support: 0
+
+- name: Income Support remains zero in future years
+  period: 2030
+  absolute_error_margin: 0
+  input:
+    people:
+      p1:
+        age: 26
+        income_support_reported: 3000
+      c1:
+        age: 4
+        is_child: true
+    benunits:
+      b1:
+        members: [p1, c1]
+        would_claim_IS: true
+    households:
+      household:
+        members: [p1, c1]
+        savings: 1000
+  output:
+    income_support: 0
+
+- name: Income-based JSA still paid in 2025 (scheme active until 31 March 2026)
+  period: 2025
+  absolute_error_margin: 5
+  input:
+    people:
+      p1:
+        age: 26
+        jsa_income_reported: 3000
+    benunits:
+      b1:
+        members: [p1]
+    households:
+      household:
+        members: [p1]
+        savings: 1000
+  output:
+    jsa_income: 3000
+
+- name: Income-based JSA is zero after scheme ended on 31 March 2026
+  period: 2026
+  absolute_error_margin: 0
+  input:
+    people:
+      p1:
+        age: 26
+        jsa_income_reported: 3000
+    benunits:
+      b1:
+        members: [p1]
+    households:
+      household:
+        members: [p1]
+        savings: 1000
+  output:
+    jsa_income: 0
+
+- name: Contribution-based JSA remains active after income-based JSA ends
+  period: 2026
+  absolute_error_margin: 0
+  input:
+    people:
+      p1:
+        age: 26
+        jsa_contrib_reported: 2500
+    benunits:
+      b1:
+        members: [p1]
+    households:
+      household:
+        members: [p1]
+  output:
+    jsa_contrib: 2500
+    jsa_income: 0

--- a/policyengine_uk/tests/policy/baseline/finance/benefit/family/jsa_income/jsa_income_capital.yaml
+++ b/policyengine_uk/tests/policy/baseline/finance/benefit/family/jsa_income/jsa_income_capital.yaml
@@ -22,7 +22,7 @@
     jsa_income_assessable_capital: 10_500
 
 - name: Income-based JSA has no tariff income at the lower capital threshold
-  period: 2026
+  period: 2025
   absolute_error_margin: 0
   input:
     people:
@@ -41,7 +41,7 @@
     jsa_income: 1_000
 
 - name: Income-based JSA tariff income rounds incomplete capital steps up
-  period: 2026
+  period: 2025
   absolute_error_margin: 0
   input:
     people:
@@ -60,7 +60,7 @@
     jsa_income: 948
 
 - name: Income-based JSA remains eligible at the upper capital limit
-  period: 2026
+  period: 2025
   absolute_error_margin: 0
   input:
     people:

--- a/policyengine_uk/variables/gov/dwp/income_support.py
+++ b/policyengine_uk/variables/gov/dwp/income_support.py
@@ -8,4 +8,8 @@ class income_support(Variable):
     definition_period = YEAR
     unit = GBP
     defined_for = "would_claim_IS"
-    adds = ["income_support_entitlement"]
+
+    def formula(benunit, period, parameters):
+        if not parameters(period).gov.dwp.income_support.active:
+            return benunit.empty_array()
+        return benunit("income_support_entitlement", period)

--- a/policyengine_uk/variables/gov/dwp/jsa_income.py
+++ b/policyengine_uk/variables/gov/dwp/jsa_income.py
@@ -13,6 +13,8 @@ class jsa_income(Variable):
     unit = GBP
 
     def formula(benunit, period, parameters):
+        if not parameters(period).gov.dwp.JSA.income.active:
+            return benunit.empty_array()
         reported_award = add(benunit, period, ["jsa_income_reported"])
         tariff_income = benunit("jsa_income_tariff_income", period)
         eligible = benunit("jsa_income_eligible", period)


### PR DESCRIPTION
## Summary
- Income Support and income-based Jobseeker's Allowance were **abolished on 31 March 2026** (last payments); DWP completed managed migration to Universal Credit with a hard cutoff.
- Mirrors the Tax Credits phase-out template from #1619.
- Adds `gov.dwp.income_support.active` and `gov.dwp.JSA.income.active` bool parameters that flip to `false` from 2026-04-01.
- Gates `income_support` and `jsa_income` formulas to return zero when inactive.
- Contribution-based JSA (`jsa_contrib`) is a separate scheme and remains active — no change.

## Why
`policyengine_uk` was overstating Income Support spending by roughly +£0.9bn vs DWP outturn because the dataset carries reported IS values from the 2022/23 FRS, which the model projects forward indefinitely. With this fix, post-migration years correctly project to zero.

References:
- [HoC Library CBP-9984: Completing Universal Credit rollout](https://commonslibrary.parliament.uk/research-briefings/cbp-9984/)
- [DWP: Successful DWP campaign leads to closure of historical benefits](https://www.gov.uk/government/news/successful-dwp-campaign-leads-to-closure-of-historical-benefits)
- [DWP: Move to Universal Credit — insight on IS and HB](https://www.gov.uk/government/publications/move-to-universal-credit-insight-on-income-support-and-housing-benefit-and-initial-esa-cohort-activity/move-to-universal-credit-insight-on-income-support-and-housing-benefit-and-initial-esa-cohort-activity)

## Test plan
- [x] New `income_support_post_migration.yaml` with 6 tests (IS active in 2025, zero in 2026+, income-based JSA active in 2025, zero in 2026+, contribution-based JSA unaffected)
- [x] Moved three existing `jsa_income_capital.yaml` tests from 2026 → 2025 (they were implicitly relying on the scheme being active)
- [x] Updated one `esa_income_capital.yaml` test: moved 2026 → 2025, adjusted expected IS entitlement accordingly
- [x] Full `policyengine_uk/tests/policy/` suite: 971 passed locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)