### PR TITLE
Bump policyengine-core to >=3.25.0

### DIFF
--- a/changelog.d/bump-pe-core-3.25.fixed.md
+++ b/changelog.d/bump-pe-core-3.25.fixed.md
@@ -1,0 +1,1 @@
+Bump `policyengine-core` minimum to `>=3.25.0` to pick up the cache-invalidation and `set_input` preservation fixes (PolicyEngine/policyengine-core#475). The 3.24.0–3.24.3 cascade left UK model tests returning zero for income_tax, UC, and other formula-driven variables when a reform is applied during simulation construction; 3.25.0 includes the regression fix.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
 ]
 requires-python = ">=3.9"
 dependencies = [
-    "policyengine-core>=3.23.6",
+    "policyengine-core>=3.25.0",
     "microdf-python>=1.2.1",
     "pydantic>=2.11.7",
     "tables>=3.9.2,<3.10.2; python_version < '3.10'",

--- a/uv.lock
+++ b/uv.lock
@@ -1557,7 +1557,7 @@ wheels = [
 
 [[package]]
 name = "policyengine-core"
-version = "3.23.6"
+version = "3.25.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "dpath", marker = "python_full_version >= '3.11'" },
@@ -1577,14 +1577,14 @@ dependencies = [
     { name = "standard-imghdr", marker = "python_full_version >= '3.11'" },
     { name = "wheel", marker = "python_full_version >= '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5d/de/5bc5b02626703ea7d288c84c474ec51e823aa726d55ebabafe7c85e7285f/policyengine_core-3.23.6.tar.gz", hash = "sha256:81bb4057f5d6380f2d7f1af2fe4932bd3bd37fdfda7b841f7ee38b30aa5cc8e6", size = 163499, upload-time = "2026-01-25T14:04:43.233Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/08/e3/40f11fe87ae718f88359dba6bf5971a1bb9b322dd48069c7881db9006791/policyengine_core-3.25.0.tar.gz", hash = "sha256:3b59a59046465d2f5c959cfe278c598e7deaa94d04a4134f4742d9f24cdbd6de", size = 464281, upload-time = "2026-04-18T00:28:02.949Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/82/7a/b47b239fb0a85a36b36b47e7665db981800fcac3384aeec6dadf92a9e548/policyengine_core-3.23.6-py3-none-any.whl", hash = "sha256:f0834107335de6f2452d39e53db7a72a57088ed26d3703a4c4eaded55a4e7bce", size = 225309, upload-time = "2026-01-25T14:04:41.844Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/f8/fd60f3c7f02d27c5c83a713cd7779707b4ddff6cd76143a9b4def1c7ec4d/policyengine_core-3.25.0-py3-none-any.whl", hash = "sha256:397127f8842dea12638880c231e6bdec346fb9c9259b7775bb060c06a3b0190b", size = 230805, upload-time = "2026-04-18T00:28:01.311Z" },
 ]
 
 [[package]]
 name = "policyengine-uk"
-version = "2.87.0"
+version = "2.88.3"
 source = { editable = "." }
 dependencies = [
     { name = "microdf-python", marker = "python_full_version >= '3.11'" },
@@ -1617,7 +1617,7 @@ requires-dist = [
     { name = "furo", marker = "extra == 'dev'", specifier = "<2023" },
     { name = "jupyter-book", marker = "extra == 'dev'", specifier = ">=2.0.0a0" },
     { name = "microdf-python", specifier = ">=1.2.1" },
-    { name = "policyengine-core", specifier = ">=3.23.6" },
+    { name = "policyengine-core", specifier = ">=3.25.0" },
     { name = "pydantic", specifier = ">=2.11.7" },
     { name = "pytest", marker = "extra == 'dev'" },
     { name = "pytest-cov", marker = "extra == 'dev'" },


### PR DESCRIPTION
## Summary
Bumps \`policyengine-core\` minimum to \`>=3.25.0\` to pick up the cache-invalidation and \`set_input\` preservation fixes from PolicyEngine/policyengine-core#475.

## Why
PE-core 3.24.0–3.24.3 introduced a cascade where \`_invalidate_all_caches\` wiped every variable's memory storage including user-provided \`set_input\` values — so any reform applied during simulation construction (the country-package pattern) silently dropped its dataset inputs. Surfaced as widespread test-suite failures where formula-driven variables (income_tax, UC, child_benefit, state_pension) returned zero. 3.25.0 preserves user inputs while still invalidating formula-output caches.

## Test plan
- [x] \`test_latest_data_smoke\` passes
- [x] \`test_lha_freeze\` passes
- [x] \`test_parametric_reform_impacts\` passes (was 49 failing on main)
- [x] \`test_uc_rebalancing\` passes

Generated with [Claude Code](https://claude.com/claude-code)