### PR TITLE
Align triple lock with published DWP / OBR uprating rates (#953)

### DIFF
--- a/changelog.d/953.md
+++ b/changelog.d/953.md
@@ -1,0 +1,1 @@
+- Align state pension triple lock with published outturn rates so basic and new state pension amounts match DWP / OBR figures for 2025-26 and 2026-27 instead of being ~1% off.

--- a/policyengine_uk/parameters/gov/dwp/state_pension/basic_state_pension/amount.yaml
+++ b/policyengine_uk/parameters/gov/dwp/state_pension/basic_state_pension/amount.yaml
@@ -23,7 +23,8 @@ values:
   2022-01-01: 141.85
   2023-01-01: 156.2
   2024-01-01: 169.5
-  2025-04-01: 172.38
+  2025-04-01: 176.45
+  2026-04-01: 184.9
 metadata:
   unit: currency-GBP
   label: Basic State Pension amount

--- a/policyengine_uk/parameters/gov/dwp/state_pension/new_state_pension/amount.yaml
+++ b/policyengine_uk/parameters/gov/dwp/state_pension/new_state_pension/amount.yaml
@@ -9,7 +9,8 @@ values:
   2022-01-01: 185.15
   2023-01-01: 203.85
   2024-01-01: 221.2
-  2025-04-01: 224.96
+  2025-04-01: 230.25
+  2026-04-01: 241.3
 metadata:
   unit: currency-GBP
   label: New State Pension amount

--- a/policyengine_uk/parameters/gov/dwp/state_pension/triple_lock/create_triple_lock.py
+++ b/policyengine_uk/parameters/gov/dwp/state_pension/triple_lock/create_triple_lock.py
@@ -13,21 +13,30 @@ def add_triple_lock(parameters: ParameterNode) -> ParameterNode:
     cpi = obr.consumer_price_index
     triple_lock = parameters.gov.dwp.state_pension.triple_lock
     min_rate = triple_lock.minimum_rate
+    # Years with a published outturn or DWP-announced rate to use directly
+    # instead of the formula (the formula relies on OBR calendar-year averages,
+    # which don't match the May-July AWE window DWP actually uses).
+    outturn_years = {int(v.instant_str[:4]) for v in triple_lock.outturn.values_list}
 
     values = {}
 
     for year in YEARS:
-        earnings_increase = average_earnings(year - 1)
-        cpi_increase = cpi(year - 1)
-        min_rate_y = min_rate(year)
-        if triple_lock.include_earnings(year) and triple_lock.include_inflation(year):
-            triple_lock_increase = max(earnings_increase, cpi_increase, min_rate_y)
-        elif triple_lock.include_earnings(year):
-            triple_lock_increase = max(earnings_increase, min_rate_y)
-        elif triple_lock.include_inflation(year):
-            triple_lock_increase = max(cpi_increase, min_rate_y)
+        if year in outturn_years:
+            triple_lock_increase = triple_lock.outturn(year)
         else:
-            triple_lock_increase = min_rate_y
+            earnings_increase = average_earnings(year - 1)
+            cpi_increase = cpi(year - 1)
+            min_rate_y = min_rate(year)
+            if triple_lock.include_earnings(year) and triple_lock.include_inflation(
+                year
+            ):
+                triple_lock_increase = max(earnings_increase, cpi_increase, min_rate_y)
+            elif triple_lock.include_earnings(year):
+                triple_lock_increase = max(earnings_increase, min_rate_y)
+            elif triple_lock.include_inflation(year):
+                triple_lock_increase = max(cpi_increase, min_rate_y)
+            else:
+                triple_lock_increase = min_rate_y
         values[f"{year}-01-01"] = round(triple_lock_increase, 3)
 
     new_parameter = Parameter(

--- a/policyengine_uk/parameters/gov/dwp/state_pension/triple_lock/outturn.yaml
+++ b/policyengine_uk/parameters/gov/dwp/state_pension/triple_lock/outturn.yaml
@@ -1,0 +1,21 @@
+description: Published triple lock uprating rates (outturn or DWP-announced). Used in preference to the max-of(earnings, CPI, minimum) formula because the formula relies on calendar-year OBR averages, while the actual uprating uses May-July AWE growth.
+values:
+  2022-01-01: 0.031
+  2023-01-01: 0.101
+  2024-01-01: 0.085
+  2025-01-01: 0.041
+  2026-01-01: 0.048
+metadata:
+  unit: /1
+  label: Triple lock outturn rate
+  reference:
+    - title: DWP benefit and pension rates 2022 to 2023
+      href: https://www.gov.uk/government/publications/benefit-and-pension-rates-2022-to-2023
+    - title: DWP benefit and pension rates 2023 to 2024
+      href: https://www.gov.uk/government/publications/benefit-and-pension-rates-2023-to-2024
+    - title: DWP benefit and pension rates 2024 to 2025
+      href: https://www.gov.uk/government/publications/benefit-and-pension-rates-2024-to-2025
+    - title: DWP benefit and pension rates 2025 to 2026
+      href: https://www.gov.uk/government/publications/benefit-and-pension-rates-2025-to-2026
+    - title: DWP benefit and pension rates 2026 to 2027
+      href: https://www.gov.uk/government/news/over-12-million-pensioners-to-receive-575-state-pension-boost

--- a/policyengine_uk/tests/test_triple_lock_outturn.py
+++ b/policyengine_uk/tests/test_triple_lock_outturn.py
@@ -1,0 +1,62 @@
+"""Verify the triple lock and downstream state pension amounts match published
+DWP / OBR uprating outturn for years where the actual rate is known.
+
+Issue #953: previously the triple lock was computed from OBR calendar-year
+average earnings growth, which differs from the May-July AWE window DWP uses
+for the actual triple lock. That left every uprating year ~0.5-1.2pp off.
+"""
+
+import pytest
+
+from policyengine_uk.system import system
+
+
+# (year, expected uprating rate). Sources are linked in
+# parameters/gov/dwp/state_pension/triple_lock/outturn.yaml.
+OUTTURN_RATES = [
+    (2022, 0.031),
+    (2023, 0.101),
+    (2024, 0.085),
+    (2025, 0.041),
+    (2026, 0.048),
+]
+
+# (year, expected weekly £). Cross-referenced against gov.uk benefit and
+# pension rates publications.
+BASIC_STATE_PENSION_WEEKLY = [
+    (2024, 169.50),
+    (2025, 176.45),
+    (2026, 184.90),
+]
+
+NEW_STATE_PENSION_WEEKLY = [
+    (2024, 221.20),
+    (2025, 230.25),
+    (2026, 241.30),
+]
+
+
+@pytest.mark.parametrize("year, expected", OUTTURN_RATES)
+def test_triple_lock_yoy_matches_published_outturn(year, expected):
+    """The generated triple lock yoy parameter should equal the DWP-announced
+    rate for years where outturn is known."""
+    yoy = system.parameters.gov.economic_assumptions.yoy_growth.triple_lock(
+        f"{year}-01-01"
+    )
+    assert yoy == pytest.approx(expected, abs=1e-3)
+
+
+@pytest.mark.parametrize("year, expected", BASIC_STATE_PENSION_WEEKLY)
+def test_basic_state_pension_matches_published_rate(year, expected):
+    weekly = system.parameters.gov.dwp.state_pension.basic_state_pension.amount(
+        f"{year}-04-01"
+    )
+    assert weekly == pytest.approx(expected, abs=0.01)
+
+
+@pytest.mark.parametrize("year, expected", NEW_STATE_PENSION_WEEKLY)
+def test_new_state_pension_matches_published_rate(year, expected):
+    weekly = system.parameters.gov.dwp.state_pension.new_state_pension.amount(
+        f"{year}-04-01"
+    )
+    assert weekly == pytest.approx(expected, abs=0.01)


### PR DESCRIPTION
## Summary
- The triple lock formula previously used OBR calendar-year average earnings, but DWP applies May-July AWE growth. That left every uprating year 0.5-1.2pp off vs published rates.
- Add `outturn.yaml` listing the published triple lock rates for 2022-2026 (3.1%, 10.1%, 8.5%, 4.1%, 4.8%) and update `create_triple_lock.py` to prefer outturn over the max-of formula when available.
- Correct the hard-coded April 2025 basic / new state pension amounts (£172.38 / £224.96 → £176.45 / £230.25) and add the April 2026 figures (£184.90 / £241.30) so basic and new state pension amounts now match DWP / OBR exactly through 2026-27. The formula still drives 2027+.

Closes #953.

## Test plan
- [x] `python -m pytest policyengine_uk/tests/test_triple_lock_outturn.py -v` — 11 new tests pass (5 triple lock yoy, 3 basic SP weekly, 3 new SP weekly).
- [x] `make format` — clean.
- [ ] Reviewer to spot-check uprating chain through `gov.economic_assumptions.indices.triple_lock` for 2027+ years.

🤖 Generated with [Claude Code](https://claude.com/claude-code)