### PR TITLE
Set Marriage Allowance take-up rate to HMRC outturn (#623)

### DIFF
--- a/changelog.d/623.md
+++ b/changelog.d/623.md
@@ -1,0 +1,1 @@
+- Set Marriage Allowance take-up rate parameter to 0.5 (HMRC outturn ~2.1m claimants of ~4.2m eligible couples) instead of the placeholder 1.0, with a House of Commons Library citation. The parallel rate in `policyengine-uk-data` is the load-bearing one for microsimulation outputs and must be updated separately.

--- a/policyengine_uk/parameters/gov/hmrc/income_tax/allowances/marriage_allowance/takeup_rate.yaml
+++ b/policyengine_uk/parameters/gov/hmrc/income_tax/allowances/marriage_allowance/takeup_rate.yaml
@@ -1,9 +1,11 @@
-description: Percentage of eligible couples who claim Marriage Allowance.
+description: Share of eligible couples who claim Marriage Allowance. HMRC outturn shows ~2.1m claimants vs ~4.2m eligible couples (~50% take-up). The matching parameter in policyengine-uk-data (`parameters/take_up/marriage_allowance.yaml`) is the load-bearing one for microsimulation, applied stochastically when populating `would_claim_marriage_allowance` per person; this file should be kept in sync.
 values:
-  2000-01-01: 1
+  2000-01-01: 0.5
 metadata:
   unit: /1
   label: Marriage Allowance take-up rate
   reference:
     - title: Income Tax Act 2007 s. 55B
       href: https://www.legislation.gov.uk/ukpga/2007/3/section/55B
+    - title: House of Commons Library — Income tax allowances for married couples (SN00870)
+      href: https://commonslibrary.parliament.uk/research-briefings/sn00870/


### PR DESCRIPTION
## Summary
- Issue #623: the Marriage Allowance take-up rate parameter was a placeholder `1.0` (100%). HMRC outturn shows ~2.1m claimants of ~4.2m eligible couples, roughly 50% take-up.
- Update [`takeup_rate.yaml`](policyengine_uk/parameters/gov/hmrc/income_tax/allowances/marriage_allowance/takeup_rate.yaml) to `0.5` with a [House of Commons Library citation](https://commonslibrary.parliament.uk/research-briefings/sn00870/).
- Document in the parameter description that the load-bearing rate for microsimulation outputs lives in `policyengine-uk-data` and must be kept in sync.

## Behavioural scope

In the baseline `policyengine-uk` model, the main [`marriage_allowance.py`](policyengine_uk/variables/gov/hmrc/income_tax/allowances/marriage_allowance.py) formula reads `would_claim_marriage_allowance`, a pre-generated 0/1 flag populated stochastically at FRS build time in `policyengine-uk-data`. For that baseline microsimulation path, the matching `policyengine-uk-data` parameter is the load-bearing one.

However, this parameter is still read directly by the CPS marriage-tax reform in [`policyengine_uk/reforms/cps/marriage_tax_reforms.py`](policyengine_uk/reforms/cps/marriage_tax_reforms.py). So this PR is not strictly documentation-only across all code paths: it also changes take-up under that reform path from 100% to 50%, which appears directionally correct.

A parallel `policyengine-uk-data` PR is still required to move baseline microsimulation outputs. See PolicyEngine/policyengine-uk-data#369 and PolicyEngine/policyengine-uk#623 for context.

## Test plan
- [x] `make format` clean
- [ ] Reviewer to confirm the 0.5 figure matches the team's preferred outturn anchor (HoC briefing cites HMRC)
- [ ] Reviewer to confirm the CPS reform path should also inherit the 0.5 take-up assumption
