### PR TITLE
Fix np.is_in typo in cps.marriage_tax_reforms (#257)

### DIFF
--- a/changelog.d/257.md
+++ b/changelog.d/257.md
@@ -1,0 +1,1 @@
+- Fix `AttributeError` in `cps.marriage_tax_reforms` when reform was instantiated with `child_education_levels` — replace nonexistent `np.is_in` (typo) with `np.isin`.

--- a/policyengine_uk/reforms/cps/marriage_tax_reforms.py
+++ b/policyengine_uk/reforms/cps/marriage_tax_reforms.py
@@ -19,7 +19,7 @@ def create_expanded_ma_reform(
                 child_meets_age_condition = person("age", period) <= max_child_age
                 return benunit.any(child_meets_age_condition)
             if child_education_levels is not None:
-                child_meets_education_condition = np.is_in(
+                child_meets_education_condition = np.isin(
                     person("education_level", period).decode_to_str(),
                     child_education_levels,
                 )
@@ -110,7 +110,7 @@ def create_marriage_neutral_income_tax_reform(
                 child_meets_age_condition = person("age", period) <= max_child_age
                 return benunit.any(child_meets_age_condition)
             if child_education_levels is not None:
-                child_meets_education_condition = np.is_in(
+                child_meets_education_condition = np.isin(
                     person("education_level", period).decode_to_str(),
                     child_education_levels,
                 )


### PR DESCRIPTION
## Summary
- Replace nonexistent `np.is_in(...)` with `np.isin(...)` in [`policyengine_uk/reforms/cps/marriage_tax_reforms.py`](policyengine_uk/reforms/cps/marriage_tax_reforms.py) lines 22 and 113.
- `np.is_in` (with underscore) does not exist in numpy. Both call sites sit inside `if child_education_levels is not None:` branches, so the typo only triggers when the reform is instantiated with that argument — at which point it raises `AttributeError`.

Found while auditing #257.

## Test plan
- [x] Module imports cleanly: `python -c "from policyengine_uk.reforms.cps.marriage_tax_reforms import *"`
- [x] `make format` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)