### PR TITLE
Pin UC vs Housing Benefit mutual-exclusion contract (#201)

### DIFF
--- a/changelog.d/201.md
+++ b/changelog.d/201.md
@@ -1,0 +1,1 @@
+- Add regression tests pinning the existing UC vs Housing Benefit mutual-exclusion contract in `housing_benefit_eligible` (`& ~claiming_uc`), so a future refactor can't silently allow simultaneous UC + HB awards.

--- a/policyengine_uk/tests/policy/baseline/finance/benefit/family/uc_legacy_mutual_exclusion.yaml
+++ b/policyengine_uk/tests/policy/baseline/finance/benefit/family/uc_legacy_mutual_exclusion.yaml
@@ -1,0 +1,27 @@
+# Regression tests for issue #201: UC and legacy benefit `claims_*` consistency.
+#
+# `housing_benefit_eligible` explicitly includes `& ~claiming_uc` so a benunit
+# claiming Universal Credit cannot also be eligible for Housing Benefit. These
+# tests pin that contract so a future refactor can't quietly break it.
+
+- name: HB eligibility excludes benunits claiming Universal Credit
+  period: 2025
+  absolute_error_margin: 0
+  input:
+    in_social_housing: true
+    housing_benefit_reported: 4_000
+    would_claim_uc: true
+    LHA_eligible: false
+  output:
+    housing_benefit_eligible: false
+
+- name: HB eligibility holds when benunit is not claiming Universal Credit
+  period: 2025
+  absolute_error_margin: 0
+  input:
+    in_social_housing: true
+    housing_benefit_reported: 4_000
+    would_claim_uc: false
+    LHA_eligible: false
+  output:
+    housing_benefit_eligible: true


### PR DESCRIPTION
## Summary
- Closes #201 (with the audit summarised in [the issue comment](https://github.com/PolicyEngine/policyengine-uk/issues/201)).
- Add yaml regression tests for [`housing_benefit_eligible`](policyengine_uk/variables/gov/dwp/housing_benefit/housing_benefit_eligible.py) covering the existing `& ~claiming_uc` clause: a benunit on Universal Credit is not HB-eligible; flipping `would_claim_uc` restores eligibility.
- Pins the contract so a future refactor can't silently allow simultaneous UC + HB awards.

## Why this is the right scope

Other legacy benefit consistency is already enforced by:
- **Reported anchors** — `jsa_income`, `esa_income` only pay reported amounts, so an unreported family doesn't double-up with UC.
- **`active.yaml` flags** — Tax Credits (5 April 2025), Income Support and income-based JSA (31 March 2026) are switched off in the parameter tree post-managed-migration, via #1619 and #1631.

The HB ↔ UC exclusion is the only live "code-level" consistency check. That's what this test pins.

## Test plan
- [x] `policyengine-core test policyengine_uk/tests/policy/baseline/finance/benefit/family/uc_legacy_mutual_exclusion.yaml -c policyengine_uk` — 2/2 pass.
- [x] `make format` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)