### PR TITLE
Fill 2020 and 2021 carbon intensities by interpolation (#396)

### DIFF
--- a/changelog.d/396.md
+++ b/changelog.d/396.md
@@ -1,0 +1,1 @@
+- Fill in 2020 and 2021 carbon intensity values for all 12 consumption categories by linear interpolation between the existing DEFRA-sourced 2019 and 2022 anchors, replacing the prior `backdate_parameters` artifact that held values flat at 2019 across the gap.

--- a/policyengine_uk/parameters/household/consumption/carbon/intensity.yaml
+++ b/policyengine_uk/parameters/household/consumption/carbon/intensity.yaml
@@ -1,39 +1,63 @@
-description: Carbon intensity by consumption type (where microsimulation data is not available)
+description: Carbon intensity by consumption type (where microsimulation data is not available). 2019 and 2022 values are sourced from the DEFRA UK Carbon Footprint dataset; 2020 and 2021 are linear-interpolated between those two points (DEFRA publishes the underlying COICOP figures, but we lack the LCFS-weighted aggregation methodology used to produce the 2-digit values for 2019 and 2022). Years after 2022 are forward-projected at -4.9%/year via `gov.economic_assumptions.indices.carbon_intensity`.
 alcohol_and_tobacco_consumption:
   2019-01-01: 7.7e-05
+  2020-01-01: 7.092333e-05
+  2021-01-01: 6.484667e-05
   2022-01-01: 0.00005877
 clothing_and_footwear_consumption:
   2019-01-01: 0.000262
+  2020-01-01: 0.00025086
+  2021-01-01: 0.00023972
   2022-01-01: 0.00022858
 communication_consumption:
   2019-01-01: 0.000404
+  2020-01-01: 0.00039425
+  2021-01-01: 0.00038449
   2022-01-01: 0.00037474
 education_consumption:
   2019-01-01: 0.000241
+  2020-01-01: 0.00028874
+  2021-01-01: 0.00033648
   2022-01-01: 0.00038422
 food_and_non_alcoholic_beverages_consumption:
   2019-01-01: 0.000689
+  2020-01-01: 0.00062852
+  2021-01-01: 0.00056804
   2022-01-01: 0.00050756
 health_consumption:
   2019-01-01: 0.000656
+  2020-01-01: 0.00065116
+  2021-01-01: 0.00064633
   2022-01-01: 0.00064149
 household_furnishings_consumption:
   2019-01-01: 0.000212
+  2020-01-01: 0.00021016
+  2021-01-01: 0.00020833
   2022-01-01: 0.00020649
 housing_water_and_electricity_consumption:
   2019-01-01: 0.0012
+  2020-01-01: 0.00111799
+  2021-01-01: 0.00103598
   2022-01-01: 0.00095397
 miscellaneous_consumption:
   2019-01-01: 0.000203
+  2020-01-01: 0.00020843
+  2021-01-01: 0.00021385
   2022-01-01: 0.00021928
 recreation_consumption:
   2019-01-01: 0.000185
+  2020-01-01: 0.00018347
+  2021-01-01: 0.00018193
   2022-01-01: 0.0001804
 restaurants_and_hotels_consumption:
   2019-01-01: 0.000311
+  2020-01-01: 0.00030431
+  2021-01-01: 0.00029761
   2022-01-01: 0.00029092
 transport_consumption:
   2019-01-01: 0.00107
+  2020-01-01: 0.00107055
+  2021-01-01: 0.00107109
   2022-01-01: 0.00107164
 metadata:
   unit: tonnes per gbp


### PR DESCRIPTION
## Summary
- Issue #396 asked for historical carbon intensities — model had only 2019 and 2022, with the gap silently held flat at the 2019 value via the generic `backdate_parameters` step.
- Add interpolated 2020 and 2021 values for all 12 [`intensity.yaml`](policyengine_uk/parameters/household/consumption/carbon/intensity.yaml) categories (linear between the existing DEFRA-sourced 2019 and 2022 anchors), so simulations covering those years use plausible intermediate values instead of a backdate artifact.
- Update the YAML `description` to document the source / methodology / forward-projection.

## Why interpolation, not DEFRA outturn

DEFRA's [UK Carbon Footprint dataset](https://www.gov.uk/government/statistics/uks-carbon-footprint) does publish annual COICOP multipliers for 2020 and 2021, but only at **3-digit COICOP** (~110 sub-categories like "1.1.1 Bread and cereals"). PolicyEngine's 12 categories are **2-digit** roll-ups, and the existing 2019/2022 values in the YAML were produced by some **LCFS expenditure-weighted aggregation** whose methodology isn't captured anywhere in the repo. Back-casting with a different aggregation would put the new years on a different scale than the existing two anchors and introduce a discontinuity. Linear interpolation between two real DEFRA-anchored values is honest — it's clearly an estimate and the YAML description says so.

If anyone later sources the original LCFS-weighting methodology, the interpolated 2020 / 2021 figures (and ideally the full 1990-2018 history) can be replaced with proper DEFRA-derived values.

## What about post-2022?

DEFRA runs roughly a **2.5-year lag** on consumption-based emissions (the 2022 release was published 14 May 2025), so 2023, 2024, 2025 and 2026 outturn aren't published yet. The model continues to forward-project these via [`gov.economic_assumptions.yoy_growth.carbon_intensity`](policyengine_uk/parameters/gov/economic_assumptions/yoy_growth.yaml) at **-4.9%/year**, which is propagated through [`gov.economic_assumptions.indices.carbon_intensity`](policyengine_uk/parameters/gov/economic_assumptions/create_economic_assumption_indices.py) and applied as the `uprating` source on `intensity.yaml`. As DEFRA publishes more recent outturn years, those should be appended to the YAML directly so the projection only kicks in past the most recent published year.

## Test plan
- [x] `make format` clean
- [x] Verified parameter values load correctly across 2019-2023, with interpolation in 2020/2021 and the -4.9%/year decline still applying from 2023 onward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)