### PR TITLE
Fix carbon intensity chart in docs (#580)

### DIFF
--- a/changelog.d/580.md
+++ b/changelog.d/580.md
@@ -1,0 +1,1 @@
+- Replace the carbon intensity chart in the carbon tax doc with a horizontal bar ranking categories, with the axis relabelled to tonnes CO2 per £1,000 (the previous chart had a nonsensical "pence/tonne" tick suffix).

--- a/docs/book/programs/contrib/ubi-center/carbon-tax.ipynb
+++ b/docs/book/programs/contrib/ubi-center/carbon-tax.ipynb
@@ -61,6 +61,12 @@
    "execution_count": 1,
    "id": "8b7f5e74-3376-42f7-8f91-44ba40e54ea4",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-24T12:13:00.455657Z",
+     "iopub.status.busy": "2026-04-24T12:13:00.455392Z",
+     "iopub.status.idle": "2026-04-24T12:13:01.472975Z",
+     "shell.execute_reply": "2026-04-24T12:13:01.472688Z"
+    },
     "tags": [
      "hide-input"
     ]
@@ -74,8 +80,7 @@
        },
        "data": [
         {
-         "alignmentgroup": "True",
-         "hovertemplate": "Category=%{x}<br>Intensity*100=%{y}<extra></extra>",
+         "hovertemplate": "Tonnes CO2 per £1,000=%{x}<br>Category=%{y}<extra></extra>",
          "legendgroup": "",
          "marker": {
           "color": "#636efa",
@@ -84,39 +89,28 @@
           }
          },
          "name": "",
-         "offsetgroup": "",
-         "orientation": "v",
+         "orientation": "h",
          "showlegend": false,
          "textposition": "auto",
          "type": "bar",
-         "x": [
-          "Housing, water and electricity",
-          "Transport",
-          "Food",
-          "Health",
-          "Communication",
-          "Restaurants and hotels",
-          "Clothing and footwear",
-          "Education",
-          "Household furnishings",
-          "Miscellaneous",
-          "Recreation",
-          "Alcohol and tobacco"
-         ],
+         "x": {
+          "bdata": "g8DKoUW2sz+uR+F6FK7HP5ZDi2zn+8k/iUFg5dAiyz8MAiuHFtnOP/hT46WbxNA/gZVDi2zn0z9CYOXQItvZP8uhRbbz/eQ/QDVeukkM5j8fhetRuB7xPzMzMzMzM/M/",
+          "dtype": "f8"
+         },
          "xaxis": "x",
          "y": [
-          0.12,
-          0.107,
-          0.0689,
-          0.0656,
-          0.0404,
-          0.031100000000000003,
-          0.0262,
-          0.0241,
-          0.0212,
-          0.0203,
-          0.0185,
-          0.0077
+          "Alcohol and tobacco",
+          "Recreation",
+          "Miscellaneous",
+          "Household furnishings",
+          "Education",
+          "Clothing and footwear",
+          "Restaurants and hotels",
+          "Communication",
+          "Health",
+          "Food",
+          "Transport",
+          "Housing, water and electricity"
          ],
          "yaxis": "y"
         }
@@ -206,7 +200,7 @@
             },
             "colorscale": [
              [
-              0,
+              0.0,
               "#0d0887"
              ],
              [
@@ -242,7 +236,7 @@
               "#fdca26"
              ],
              [
-              1,
+              1.0,
               "#f0f921"
              ]
             ],
@@ -266,7 +260,7 @@
             },
             "colorscale": [
              [
-              0,
+              0.0,
               "#0d0887"
              ],
              [
@@ -302,62 +296,11 @@
               "#fdca26"
              ],
              [
-              1,
+              1.0,
               "#f0f921"
              ]
             ],
             "type": "heatmap"
-           }
-          ],
-          "heatmapgl": [
-           {
-            "colorbar": {
-             "outlinewidth": 0,
-             "ticks": ""
-            },
-            "colorscale": [
-             [
-              0,
-              "#0d0887"
-             ],
-             [
-              0.1111111111111111,
-              "#46039f"
-             ],
-             [
-              0.2222222222222222,
-              "#7201a8"
-             ],
-             [
-              0.3333333333333333,
-              "#9c179e"
-             ],
-             [
-              0.4444444444444444,
-              "#bd3786"
-             ],
-             [
-              0.5555555555555556,
-              "#d8576b"
-             ],
-             [
-              0.6666666666666666,
-              "#ed7953"
-             ],
-             [
-              0.7777777777777778,
-              "#fb9f3a"
-             ],
-             [
-              0.8888888888888888,
-              "#fdca26"
-             ],
-             [
-              1,
-              "#f0f921"
-             ]
-            ],
-            "type": "heatmapgl"
            }
           ],
           "histogram": [
@@ -380,7 +323,7 @@
             },
             "colorscale": [
              [
-              0,
+              0.0,
               "#0d0887"
              ],
              [
@@ -416,7 +359,7 @@
               "#fdca26"
              ],
              [
-              1,
+              1.0,
               "#f0f921"
              ]
             ],
@@ -431,7 +374,7 @@
             },
             "colorscale": [
              [
-              0,
+              0.0,
               "#0d0887"
              ],
              [
@@ -467,7 +410,7 @@
               "#fdca26"
              ],
              [
-              1,
+              1.0,
               "#f0f921"
              ]
             ],
@@ -502,11 +445,10 @@
           ],
           "scatter": [
            {
-            "marker": {
-             "colorbar": {
-              "outlinewidth": 0,
-              "ticks": ""
-             }
+            "fillpattern": {
+             "fillmode": "overlay",
+             "size": 10,
+             "solidity": 0.2
             },
             "type": "scatter"
            }
@@ -561,6 +503,17 @@
             "type": "scattergl"
            }
           ],
+          "scattermap": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattermap"
+           }
+          ],
           "scattermapbox": [
            {
             "marker": {
@@ -613,7 +566,7 @@
             },
             "colorscale": [
              [
-              0,
+              0.0,
               "#0d0887"
              ],
              [
@@ -649,7 +602,7 @@
               "#fdca26"
              ],
              [
-              1,
+              1.0,
               "#f0f921"
              ]
             ],
@@ -740,7 +693,7 @@
            ],
            "sequential": [
             [
-             0,
+             0.0,
              "#0d0887"
             ],
             [
@@ -776,13 +729,13 @@
              "#fdca26"
             ],
             [
-             1,
+             1.0,
              "#f0f921"
             ]
            ],
            "sequentialminus": [
             [
-             0,
+             0.0,
              "#0d0887"
             ],
             [
@@ -818,7 +771,7 @@
              "#fdca26"
             ],
             [
-             1,
+             1.0,
              "#f0f921"
             ]
            ]
@@ -948,29 +901,26 @@
          }
         },
         "title": {
-         "text": "Tonnes of CO2 per pound by category"
+         "text": "Carbon intensity by consumption category"
         },
         "width": 800,
         "xaxis": {
          "anchor": "y",
          "domain": [
-          0,
-          1
+          0.0,
+          1.0
          ],
          "title": {
-          "text": "Category"
+          "text": "Tonnes CO2 per £1,000"
          }
         },
         "yaxis": {
          "anchor": "x",
          "domain": [
-          0,
-          1
+          0.0,
+          1.0
          ],
-         "ticksuffix": " pence/tonne",
-         "title": {
-          "text": "Intensity*100"
-         }
+         "title": {}
         }
        }
       }
@@ -1016,18 +966,19 @@
     "    }\n",
     ")\n",
     "\n",
-    "df[\"Intensity*100\"] = df.Intensity * 100\n",
+    "df[\"Tonnes CO2 per £1,000\"] = df.Intensity * 1000\n",
     "\n",
     "px.bar(\n",
-    "    df.sort_values(\"Intensity\", ascending=False),\n",
-    "    x=\"Category\",\n",
-    "    y=\"Intensity*100\",\n",
+    "    df.sort_values(\"Tonnes CO2 per £1,000\", ascending=True),\n",
+    "    x=\"Tonnes CO2 per £1,000\",\n",
+    "    y=\"Category\",\n",
+    "    orientation=\"h\",\n",
     ").update_layout(\n",
-    "    title=\"Tonnes of CO2 per pound by category\",\n",
-    "    yaxis_ticksuffix=\" pence/tonne\",\n",
+    "    title=\"Carbon intensity by consumption category\",\n",
+    "    yaxis_title=None,\n",
     "    width=800,\n",
     "    height=600,\n",
-    ")"
+    ")\n"
    ]
   }
  ],
@@ -1047,7 +998,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.12"
+   "version": "3.10.13"
   },
   "vscode": {
    "interpreter": {


### PR DESCRIPTION
## Summary
- In `docs/book/programs/contrib/ubi-center/carbon-tax.ipynb`, flip the carbon intensity bar chart from vertical to horizontal so long category names are readable, remove the `Category` axis label, and relabel the value axis to `Tonnes CO2 per £1,000` (the chart previously scaled intensity by 100 and used a nonsensical `pence/tonne` tick suffix).
- Re-execute the notebook so the built jupyter-book renders the updated chart (`execute_notebooks: off` in `_config.yml`, so outputs stored in the `.ipynb` are what ship to docs).

Closes #580.

Out of scope for this PR: the issue also asks to update the chart in Nikhil's old blog post — that lives outside this repo.

## Test plan
- [x] Notebook executes cleanly locally (`nbclient`, plotly 6.7.0).
- [x] Inspected the regenerated plotly JSON: `orientation=h`, x-axis title = `Tonnes CO2 per £1,000`, y-axis title empty, categories sorted so the largest (Housing, water and electricity) is at the top.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)