### PR TITLE
Cite legislation.gov.uk for benefit cap (#326)

### DIFF
--- a/changelog.d/326.md
+++ b/changelog.d/326.md
@@ -1,0 +1,1 @@
+- Cite SI 2016/909 reg. 2 on the benefit cap parameter, which is where the 2016-11-07 values originate.

--- a/policyengine_uk/parameters/gov/dwp/benefit_cap.yaml
+++ b/policyengine_uk/parameters/gov/dwp/benefit_cap.yaml
@@ -38,6 +38,8 @@ non_single:
       2024-04-01: 22_020
       2025-04-01: 22_020
 metadata:
-  reference: 
+  reference:
+    - title: The Benefit Cap (Housing Benefit and Universal Credit) (Amendment) Regulations 2016 reg. 2
+      href: https://www.legislation.gov.uk/uksi/2016/909/regulation/2/made
     - title: The Universal Credit Regulations 2013 reg. 80A
       href: https://www.legislation.gov.uk/uksi/2013/376/regulation/80A


### PR DESCRIPTION
## Summary
- Add [SI 2016/909 reg. 2](https://www.legislation.gov.uk/uksi/2016/909/regulation/2/made) as a reference on `parameters/gov/dwp/benefit_cap.yaml`. That SI (The Benefit Cap (Housing Benefit and Universal Credit) (Amendment) Regulations 2016) is what set the cap values the file currently uses from the `2016-11-07` start date.
- Keep the existing reference to UC Regulations 2013 reg. 80A — 80A is the application logic, and it was inserted into the UC Regs by that same 2016 SI, so the two references are complementary.

Closes #326.

## Test plan
- [x] `CountryTaxBenefitSystem().parameters.gov.dwp.benefit_cap.metadata["reference"]` exposes both references.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)