### PR TITLE
Use np.isin for country check in winter_fuel_allowance (#257)

### DIFF
--- a/changelog.d/257-winter-fuel.md
+++ b/changelog.d/257-winter-fuel.md
@@ -1,0 +1,1 @@
+- Use `np.isin` instead of OR-chained equality in `winter_fuel_allowance`.

--- a/policyengine_uk/variables/gov/dwp/winter_fuel_allowance.py
+++ b/policyengine_uk/variables/gov/dwp/winter_fuel_allowance.py
@@ -29,7 +29,7 @@ class winter_fuel_allowance(Variable):
         taxable_income = household.members("total_income", period)
         is_SP_age = household.members("is_SP_age", period)
         country = household("country", period).decode_to_str()
-        in_england_or_wales = (country == "ENGLAND") | (country == "WALES")
+        in_england_or_wales = np.isin(country, ["ENGLAND", "WALES"])
         meets_income_passport = (
             household.any(
                 is_SP_age


### PR DESCRIPTION
## Summary
Replace `(country == "ENGLAND") | (country == "WALES")` in `policyengine_uk/variables/gov/dwp/winter_fuel_allowance.py` with `np.isin(country, ["ENGLAND", "WALES"])`, per the cleanup asked for in #257.

This is one of only two OR-chained equality patterns still in the repo — the other is `(band == bands.HIGHER) | (band == bands.ADDITIONAL)` in `reforms/cps/marriage_tax_reforms.py`, which I left alone: `np.isin` does not work on raw `EnumArray` (verified empirically — it returns all-False). Making that one work with `np.isin` would require first calling `.decode_to_str()` and comparing against string names, which is less idiomatic than the current enum comparison, so that cleanup is arguably not an improvement.

Closes #257 — leaves the codebase free of genuine OR-chained equality cases where `np.isin` is a clearer alternative.

## Test plan
- [x] All 6 baseline YAML tests in `policyengine_uk/tests/policy/baseline/gov/dwp/winter_fuel_allowance.yaml` pass.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)