### PR TITLE
Make NI Class 3 a pure input

### DIFF
--- a/policyengine_uk/tests/code_health/test_input_variable_definitions.py
+++ b/policyengine_uk/tests/code_health/test_input_variable_definitions.py
@@ -1,0 +1,34 @@
+from policyengine_uk import CountryTaxBenefitSystem
+
+
+def test_input_variables_do_not_use_defined_for():
+    system = CountryTaxBenefitSystem()
+
+    invalid = {
+        name: variable.defined_for
+        for name, variable in system.variables.items()
+        if variable.is_input_variable() and variable.defined_for is not None
+    }
+
+    assert invalid == {}
+
+
+def test_input_variables_do_not_use_formulas_adds_or_subtracts():
+    system = CountryTaxBenefitSystem()
+
+    invalid = {
+        name: {
+            "formulas": bool(getattr(variable, "formulas", None)),
+            "adds": bool(getattr(variable, "adds", None)),
+            "subtracts": bool(getattr(variable, "subtracts", None)),
+        }
+        for name, variable in system.variables.items()
+        if variable.is_input_variable()
+        and (
+            getattr(variable, "formulas", None)
+            or getattr(variable, "adds", None)
+            or getattr(variable, "subtracts", None)
+        )
+    }
+
+    assert invalid == {}

--- a/policyengine_uk/variables/gov/hmrc/national_insurance/class_3/ni_class_3.py
+++ b/policyengine_uk/variables/gov/hmrc/national_insurance/class_3/ni_class_3.py
@@ -8,5 +8,4 @@ class ni_class_3(Variable):
     definition_period = YEAR
     value_type = float
     unit = GBP
-    defined_for = "ni_liable"
     reference = "https://www.legislation.gov.uk/ukpga/1992/4/section/13"


### PR DESCRIPTION
## Summary
- remove the `defined_for = "ni_liable"` gate from `ni_class_3`, making voluntary NI Class 3 contributions a pure input
- add code-health tests preventing input variables from using `defined_for`, formulas, adds, or subtracts

## Testing
- `uv run ruff format policyengine_uk/tests/code_health/test_input_variable_definitions.py policyengine_uk/variables/gov/hmrc/national_insurance/class_3/ni_class_3.py`
- `uv run ruff check policyengine_uk/tests/code_health/test_input_variable_definitions.py policyengine_uk/variables/gov/hmrc/national_insurance/class_3/ni_class_3.py`
- `uv run pytest policyengine_uk/tests/code_health/test_input_variable_definitions.py`
- `uv run policyengine-core test policyengine_uk/tests/policy/baseline/gov/hmrc/national_insurance/national_insurance.yaml -c policyengine_uk`
