### PR TITLE
Fix children receiving negative Marriage Allowance (#1666)

### DIFF
--- a/changelog.d/1666.md
+++ b/changelog.d/1666.md
@@ -1,0 +1,1 @@
+- Prevent children in a married benefit unit from being assigned (negative) Marriage Allowance and being taxed on phantom income.

--- a/policyengine_uk/tests/policy/baseline/gov/hmrc/income_tax/allowances/marriage_allowance.yaml
+++ b/policyengine_uk/tests/policy/baseline/gov/hmrc/income_tax/allowances/marriage_allowance.yaml
@@ -39,3 +39,26 @@
       is_married: true
   output:
     marriage_allowance: [0, 0]
+
+# Regression test for issue #1666: children in a married benefit unit must not
+# receive (negative) Marriage Allowance and must not be taxed on phantom income.
+- name: Children in married benunit do not transfer Marriage Allowance
+  period: 2026
+  input:
+    people:
+      adult1:
+        age: 42
+        employment_income: 55_000
+      adult2:
+        age: 40
+        employment_income: 35_000
+      child1:
+        age: 8
+      child2:
+        age: 3
+    benunit:
+      members: [adult1, adult2, child1, child2]
+      is_married: true
+  output:
+    marriage_allowance: [0, 0, 0, 0]
+    income_tax: [9_432, 4_486, 0, 0]

--- a/policyengine_uk/variables/gov/hmrc/income_tax/allowances/marriage_allowance.py
+++ b/policyengine_uk/variables/gov/hmrc/income_tax/allowances/marriage_allowance.py
@@ -27,14 +27,17 @@ class marriage_allowance(Variable):
     def formula(person, period, parameters):
         marital = person("marital_status", period)
         married = marital == marital.possible_values.MARRIED
-        eligible = married & person(
-            "meets_marriage_allowance_income_conditions", period
+        is_adult = person("is_adult", period)
+        eligible = (
+            married
+            & is_adult
+            & person("meets_marriage_allowance_income_conditions", period)
         )
         transferable_amount = person("partners_unused_personal_allowance", period)
         allowances = parameters(period).gov.hmrc.income_tax.allowances
         capped_percentage = allowances.marriage_allowance.max
         max_amount = allowances.personal_allowance.amount * capped_percentage
-        amount_if_eligible_pre_rounding = min_(transferable_amount, max_amount)
+        amount_if_eligible_pre_rounding = max_(min_(transferable_amount, max_amount), 0)
         # Round up.
         rounding_increment = allowances.marriage_allowance.rounding_increment
         amount_if_eligible = (

--- a/policyengine_uk/variables/gov/hmrc/income_tax/allowances/partners_unused_personal_allowance.py
+++ b/policyengine_uk/variables/gov/hmrc/income_tax/allowances/partners_unused_personal_allowance.py
@@ -15,4 +15,7 @@ class partners_unused_personal_allowance(Variable):
     def formula(person, period, parameters):
         is_adult = person("is_adult", period)
         pa = person("unused_personal_allowance", period)
-        return person.benunit.sum(is_adult * pa) - pa
+        # Subtract this person's own unused PA only if they are an adult, so
+        # non-adults (whose PA isn't part of the adult-summed pool) cannot
+        # produce a negative transferable amount.
+        return person.benunit.sum(is_adult * pa) - is_adult * pa


### PR DESCRIPTION
## Summary
- Closes #1666. Children in a married benefit unit were being assigned `MaritalStatus.MARRIED` and tax band `NONE`, so they cleared every Marriage Allowance gate. `partners_unused_personal_allowance` then went negative for them (their own £12,570 PA minus zero adult-summed unused PA), `marriage_allowance` did not clamp the negative through, and `earned_taxable_income` ended up adding £12,570 of phantom income — taxed at 20% = £2,514 per child.
- Fix is defence-in-depth at two points:
  - `marriage_allowance`: gate eligibility on `is_adult` and clamp the eligible amount at `>= 0`.
  - `partners_unused_personal_allowance`: subtract the person's own PA only when they are an adult (mirrors how the benunit sum is built), so non-adults get `0` rather than `-pa`.
- Leaves `marital_status` and `eligible_bands` semantics unchanged so other variables that depend on them are not affected.

## Test plan
- [x] New YAML case in `marriage_allowance.yaml`: a married benunit with two adults (£55k / £35k) and two children (ages 8, 3) — `marriage_allowance` is `[0, 0, 0, 0]` and `income_tax` is `[9432, 4486, 0, 0]`.
- [x] Existing `marriage_allowance.yaml` cases still pass (no regression for the basic married-couple scenarios).
- [x] All other YAML tests in `gov/hmrc/income_tax/allowances/` pass — the one failure (`meets_marriage_allowance_income_conditions`/regression for #395) reproduces on `main` without these changes, so it is not caused by this PR.
- [x] Manual repro from the issue body now returns `marriage_allowance = [0, 0, 0, 0]`, `income_tax = [9432, 4486, 0, 0]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)