### PR TITLE
Use deterministic Marriage Allowance take-up in CPS reform

### DIFF
--- a/changelog.d/1676.changed.md
+++ b/changelog.d/1676.changed.md
@@ -1,0 +1,1 @@
+Make the CPS expanded Marriage Allowance reform use the explicit `would_claim_marriage_allowance` input instead of formula-time randomness.

--- a/policyengine_uk/reforms/cps/marriage_tax_reforms.py
+++ b/policyengine_uk/reforms/cps/marriage_tax_reforms.py
@@ -63,7 +63,6 @@ def create_expanded_ma_reform(
             )
             transferable_amount = person("partners_unused_personal_allowance", period)
             allowances = parameters(period).gov.hmrc.income_tax.allowances
-            takeup_rate = allowances.marriage_allowance.takeup_rate
             capped_percentage = allowances.marriage_allowance.max
             expanded_ma_cap = parameters(
                 period
@@ -81,7 +80,7 @@ def create_expanded_ma_reform(
                 np.ceil(amount_if_eligible_pre_rounding / rounding_increment)
                 * rounding_increment
             )
-            takes_up = random(person) < takeup_rate
+            takes_up = person("would_claim_marriage_allowance", period)
             return eligible * amount_if_eligible * takes_up
 
     class reform(Reform):

--- a/policyengine_uk/tests/policy/reforms/cps/marriage_tax_reforms.yaml
+++ b/policyengine_uk/tests/policy/reforms/cps/marriage_tax_reforms.yaml
@@ -56,6 +56,32 @@
     # Low earner's partner has no unused PA to transfer, so low_earner's MA is 0.
     marriage_allowance: [1260, 0]
 
+- name: Expanded MA — explicit Marriage Allowance take-up input drives the reform
+  period: 2024
+  absolute_error_margin: 10
+  reforms:
+    - policyengine_uk.reforms.cps.marriage_tax_reforms.expanded_ma_reform
+  input:
+    gov.hmrc.income_tax.allowances.marriage_allowance.takeup_rate: 0.0
+    people:
+      high_earner:
+        age: 35
+        employment_income: 60_000
+        would_claim_marriage_allowance: true
+      low_earner:
+        age: 33
+        employment_income: 10_000
+        would_claim_marriage_allowance: true
+    benunits:
+      benunit:
+        members: [high_earner, low_earner]
+        is_married: true
+    households:
+      household:
+        members: [high_earner, low_earner]
+  output:
+    marriage_allowance: [1260, 0]
+
 - name: Marriage-neutral IT — single person's adjusted net income is unchanged by the reform
   period: 2024
   absolute_error_margin: 1
@@ -100,3 +126,29 @@
         members: [high_earner, low_earner]
   output:
     adjusted_net_income: [35_000, 35_000]
+
+- name: Expanded MA — explicit no-claim input suppresses the reform even with full take-up rate
+  period: 2024
+  absolute_error_margin: 10
+  reforms:
+    - policyengine_uk.reforms.cps.marriage_tax_reforms.expanded_ma_reform
+  input:
+    gov.hmrc.income_tax.allowances.marriage_allowance.takeup_rate: 1.0
+    people:
+      high_earner:
+        age: 35
+        employment_income: 60_000
+        would_claim_marriage_allowance: false
+      low_earner:
+        age: 33
+        employment_income: 10_000
+        would_claim_marriage_allowance: false
+    benunits:
+      benunit:
+        members: [high_earner, low_earner]
+        is_married: true
+    households:
+      household:
+        members: [high_earner, low_earner]
+  output:
+    marriage_allowance: [0, 0]


### PR DESCRIPTION
## Summary
- make the CPS expanded Marriage Allowance reform read `would_claim_marriage_allowance` instead of calling formula-time `random()`
- add a YAML regression where the take-up parameter is zero but the explicit take-up input is true
- leave stochastic take-up responsibility with UK data construction / explicit inputs

## TDD / verification
- Confirmed the new YAML regression failed before the implementation: the reform returned `[0, 0]` while it still called `random(person) < takeup_rate`.
- `uv run --no-sync policyengine-core test policyengine_uk/tests/policy/reforms/cps/marriage_tax_reforms.yaml -c policyengine_uk`
- `uv run --no-sync ruff check policyengine_uk/reforms/cps/marriage_tax_reforms.py`
- `uv run --no-sync ruff format --check policyengine_uk/reforms/cps/marriage_tax_reforms.py`

## Review
- Read-only subagent review requested before merge.