### PR TITLE
Remove mixed computation metadata from variables

### DIFF
--- a/changelog.d/remove-uprating-from-formula-variables.changed.md
+++ b/changelog.d/remove-uprating-from-formula-variables.changed.md
@@ -1,0 +1,1 @@
+Remove redundant uprating metadata and class-level aggregation metadata from variables that already define their computation explicitly.

--- a/policyengine_uk/variables/contrib/policyengine/pre_budget_change_household_benefits.py
+++ b/policyengine_uk/variables/contrib/policyengine/pre_budget_change_household_benefits.py
@@ -1,6 +1,41 @@
 from policyengine_uk.model_api import *
 
 
+PRE_BUDGET_CHANGE_HOUSEHOLD_BENEFIT_VARIABLES = [
+    "child_benefit",
+    "council_tax_benefit",
+    "esa_income",
+    "housing_benefit",
+    "income_support",
+    "jsa_income",
+    "pension_credit",
+    "universal_credit",
+    "working_tax_credit",
+    "child_tax_credit",
+    "attendance_allowance",
+    "afcs",
+    "bsp",
+    "carers_allowance",
+    "dla",
+    "esa_contrib",
+    "iidb",
+    "incapacity_benefit",
+    "jsa_contrib",
+    "pip",
+    "sda",
+    "state_pension",
+    "maternity_allowance",
+    "statutory_sick_pay",
+    "statutory_maternity_pay",
+    "ssmg",
+    "basic_income",
+    "epg_subsidy",
+    "cost_of_living_support_payment",
+    "energy_bills_rebate",
+    "carer_support_payment",
+]
+
+
 class pre_budget_change_household_benefits(Variable):
     value_type = float
     entity = Household
@@ -8,44 +43,11 @@ class pre_budget_change_household_benefits(Variable):
     documentation = "Total value of benefits received by household"
     definition_period = YEAR
     unit = GBP
-    adds = [
-        "child_benefit",
-        "council_tax_benefit",
-        "esa_income",
-        "housing_benefit",
-        "income_support",
-        "jsa_income",
-        "pension_credit",
-        "universal_credit",
-        "working_tax_credit",
-        "child_tax_credit",
-        "attendance_allowance",
-        "afcs",
-        "bsp",
-        "carers_allowance",
-        "dla",
-        "esa_contrib",
-        "iidb",
-        "incapacity_benefit",
-        "jsa_contrib",
-        "pip",
-        "sda",
-        "state_pension",
-        "maternity_allowance",
-        "statutory_sick_pay",
-        "statutory_maternity_pay",
-        "ssmg",
-        "basic_income",
-        "epg_subsidy",
-        "cost_of_living_support_payment",
-        "energy_bills_rebate",
-        "carer_support_payment",
-    ]
 
     def formula(household, period, parameters):
         contrib = parameters(period).gov.contrib
         uprating = contrib.benefit_uprating
-        benefits = pre_budget_change_household_benefits.adds
+        benefits = PRE_BUDGET_CHANGE_HOUSEHOLD_BENEFIT_VARIABLES
         if contrib.abolish_council_tax:
             benefits = [
                 benefit for benefit in benefits if benefit != "council_tax_benefit"

--- a/policyengine_uk/variables/contrib/policyengine/pre_budget_change_household_tax.py
+++ b/policyengine_uk/variables/contrib/policyengine/pre_budget_change_household_tax.py
@@ -1,6 +1,27 @@
 from policyengine_uk.model_api import *
 
 
+PRE_BUDGET_CHANGE_HOUSEHOLD_TAX_VARIABLES = [
+    "expected_sdlt",
+    "expected_ltt",
+    "expected_lbtt",
+    "corporate_sdlt",
+    "business_rates",
+    "council_tax",
+    "domestic_rates",
+    "fuel_duty",
+    "tv_licence",
+    "wealth_tax",
+    "non_primary_residence_wealth_tax",
+    "income_tax",
+    "national_insurance",
+    "LVT",
+    "carbon_tax",
+    "vat_change",
+    "capital_gains_tax",
+]
+
+
 class pre_budget_change_household_tax(Variable):
     value_type = float
     entity = Household
@@ -8,25 +29,6 @@ class pre_budget_change_household_tax(Variable):
     documentation = "Total taxes owed by the household"
     definition_period = YEAR
     unit = GBP
-    adds = [
-        "expected_sdlt",
-        "expected_ltt",
-        "expected_lbtt",
-        "corporate_sdlt",
-        "business_rates",
-        "council_tax",
-        "domestic_rates",
-        "fuel_duty",
-        "tv_licence",
-        "wealth_tax",
-        "non_primary_residence_wealth_tax",
-        "income_tax",
-        "national_insurance",
-        "LVT",
-        "carbon_tax",
-        "vat_change",
-        "capital_gains_tax",
-    ]
 
     def formula(household, period, parameters):
         abolish_council_tax = parameters.gov.contrib.abolish_council_tax(period)
@@ -36,9 +38,9 @@ class pre_budget_change_household_tax(Variable):
                 period,
                 [
                     tax
-                    for tax in pre_budget_change_household_tax.adds
+                    for tax in PRE_BUDGET_CHANGE_HOUSEHOLD_TAX_VARIABLES
                     if tax not in ["council_tax"]
                 ],
             )
         else:
-            return add(household, period, pre_budget_change_household_tax.adds)
+            return add(household, period, PRE_BUDGET_CHANGE_HOUSEHOLD_TAX_VARIABLES)

--- a/policyengine_uk/variables/gov/dwp/state_pension_reported.py
+++ b/policyengine_uk/variables/gov/dwp/state_pension_reported.py
@@ -7,7 +7,6 @@ class state_pension_reported(Variable):
     label = "Reported income from the State Pension"
     definition_period = YEAR
     unit = GBP
-    uprating = "gov.economic_assumptions.indices.obr.consumer_price_index"
 
     def formula_2022(person, period, parameters):
         return person("state_pension_reported", period.last_year)

--- a/policyengine_uk/variables/gov/gov_spending.py
+++ b/policyengine_uk/variables/gov/gov_spending.py
@@ -1,6 +1,58 @@
 from policyengine_uk.model_api import *
 
 
+GOV_SPENDING_VARIABLES = [
+    "child_benefit",
+    "council_tax_benefit",
+    "esa_income",
+    "esa_contrib",
+    "housing_benefit",
+    "income_support",
+    "jsa_income",
+    "jsa_contrib",
+    "pension_credit",
+    "universal_credit",
+    "working_tax_credit",
+    "child_tax_credit",
+    "attendance_allowance",
+    "afcs",
+    "bsp",
+    "carers_allowance",
+    "dla",
+    "iidb",
+    "incapacity_benefit",
+    "pip",
+    "sda",
+    "state_pension",
+    "maternity_allowance",
+    "statutory_sick_pay",
+    "statutory_maternity_pay",
+    "ssmg",
+    "basic_income",
+    "epg_subsidy",
+    "cost_of_living_support_payment",
+    "energy_bills_rebate",
+    "winter_fuel_allowance",
+    "pawhp",
+    "other_public_spending_budget_change",
+    "tax_free_childcare",
+    "extended_childcare_entitlement",
+    "universal_childcare_entitlement",
+    "targeted_childcare_entitlement",
+    "care_to_learn",
+    "childcare_grant",
+    "parents_learning_allowance",
+    "adult_dependants_grant",
+    "travel_grant",
+    "disabled_students_allowance",
+    "bursary_fund_16_to_19",
+    "dfe_education_spending",
+    "dft_subsidy_spending",
+    "nhs_spending",
+    "carer_support_payment",
+]
+
+
 class gov_spending(Variable):
     label = "government spending"
     documentation = "Government spending impact in respect of this household."
@@ -8,59 +60,9 @@ class gov_spending(Variable):
     definition_period = YEAR
     value_type = float
     unit = GBP
-    adds = [
-        "child_benefit",
-        "council_tax_benefit",
-        "esa_income",
-        "esa_contrib",
-        "housing_benefit",
-        "income_support",
-        "jsa_income",
-        "jsa_contrib",
-        "pension_credit",
-        "universal_credit",
-        "working_tax_credit",
-        "child_tax_credit",
-        "attendance_allowance",
-        "afcs",
-        "bsp",
-        "carers_allowance",
-        "dla",
-        "iidb",
-        "incapacity_benefit",
-        "pip",
-        "sda",
-        "state_pension",
-        "maternity_allowance",
-        "statutory_sick_pay",
-        "statutory_maternity_pay",
-        "ssmg",
-        "basic_income",
-        "epg_subsidy",
-        "cost_of_living_support_payment",
-        "energy_bills_rebate",
-        "winter_fuel_allowance",
-        "pawhp",
-        "other_public_spending_budget_change",
-        "tax_free_childcare",
-        "extended_childcare_entitlement",
-        "universal_childcare_entitlement",
-        "targeted_childcare_entitlement",
-        "care_to_learn",
-        "childcare_grant",
-        "parents_learning_allowance",
-        "adult_dependants_grant",
-        "travel_grant",
-        "disabled_students_allowance",
-        "bursary_fund_16_to_19",
-        "dfe_education_spending",
-        "dft_subsidy_spending",
-        "nhs_spending",
-        "carer_support_payment",
-    ]
 
     def formula(household, period, parameters):
-        variables = list(gov_spending.adds)
+        variables = list(GOV_SPENDING_VARIABLES)
         abolish_council_tax = parameters.gov.contrib.abolish_council_tax(period)
         if abolish_council_tax:
             variables = [v for v in variables if v != "council_tax_benefit"]

--- a/policyengine_uk/variables/gov/gov_tax.py
+++ b/policyengine_uk/variables/gov/gov_tax.py
@@ -1,6 +1,33 @@
 from policyengine_uk.model_api import *
 
 
+GOV_TAX_VARIABLES = [
+    "expected_sdlt",
+    "expected_ltt",
+    "expected_lbtt",
+    "corporate_sdlt",
+    "business_rates",
+    "council_tax",
+    "high_value_council_tax_surcharge",
+    "domestic_rates",
+    "fuel_duty",
+    "tv_licence",
+    "wealth_tax",
+    "non_primary_residence_wealth_tax",
+    "income_tax",
+    "national_insurance",
+    "LVT",
+    "carbon_tax",
+    "capital_gains_tax",
+    "private_school_vat",
+    "corporate_incident_tax_revenue_change",
+    "consumer_incident_tax_revenue_change",
+    "ni_employer",
+    "student_loan_repayments",
+    "vat",
+]
+
+
 class gov_tax(Variable):
     label = "government tax revenue"
     documentation = "Government tax revenue impact in respect of this household."
@@ -8,34 +35,9 @@ class gov_tax(Variable):
     definition_period = YEAR
     value_type = float
     unit = GBP
-    adds = [
-        "expected_sdlt",
-        "expected_ltt",
-        "expected_lbtt",
-        "corporate_sdlt",
-        "business_rates",
-        "council_tax",
-        "high_value_council_tax_surcharge",
-        "domestic_rates",
-        "fuel_duty",
-        "tv_licence",
-        "wealth_tax",
-        "non_primary_residence_wealth_tax",
-        "income_tax",
-        "national_insurance",
-        "LVT",
-        "carbon_tax",
-        "capital_gains_tax",
-        "private_school_vat",
-        "corporate_incident_tax_revenue_change",
-        "consumer_incident_tax_revenue_change",
-        "ni_employer",
-        "student_loan_repayments",
-        "vat",
-    ]
 
     def formula(household, period, parameters):
-        variables = list(gov_tax.adds)
+        variables = list(GOV_TAX_VARIABLES)
         abolish_council_tax = parameters.gov.contrib.abolish_council_tax(period)
         if abolish_council_tax:
             variables = [

--- a/policyengine_uk/variables/gov/hmrc/household_tax.py
+++ b/policyengine_uk/variables/gov/hmrc/household_tax.py
@@ -1,6 +1,34 @@
 from policyengine_uk.model_api import *
 
 
+HOUSEHOLD_TAX_VARIABLES = [
+    "expected_sdlt",
+    "expected_ltt",
+    "expected_lbtt",
+    "corporate_sdlt",
+    "business_rates",
+    "council_tax",
+    "high_value_council_tax_surcharge",
+    "domestic_rates",
+    "fuel_duty",
+    "tv_licence",
+    "wealth_tax",
+    "non_primary_residence_wealth_tax",
+    "income_tax",
+    "national_insurance",
+    "LVT",
+    "carbon_tax",
+    "vat_change",
+    "capital_gains_tax",
+    "private_school_vat",
+    "corporate_incident_tax_revenue_change",
+    "consumer_incident_tax_revenue_change",
+    "employer_ni_response_capital_incidence",
+    "employer_ni_response_consumer_incidence",
+    "student_loan_repayments",
+]
+
+
 class household_tax(Variable):
     value_type = float
     entity = Household
@@ -8,32 +36,6 @@ class household_tax(Variable):
     documentation = "Total taxes owed by the household"
     definition_period = YEAR
     unit = GBP
-    adds = [
-        "expected_sdlt",
-        "expected_ltt",
-        "expected_lbtt",
-        "corporate_sdlt",
-        "business_rates",
-        "council_tax",
-        "high_value_council_tax_surcharge",
-        "domestic_rates",
-        "fuel_duty",
-        "tv_licence",
-        "wealth_tax",
-        "non_primary_residence_wealth_tax",
-        "income_tax",
-        "national_insurance",
-        "LVT",
-        "carbon_tax",
-        "vat_change",
-        "capital_gains_tax",
-        "private_school_vat",
-        "corporate_incident_tax_revenue_change",
-        "consumer_incident_tax_revenue_change",
-        "employer_ni_response_capital_incidence",
-        "employer_ni_response_consumer_incidence",
-        "student_loan_repayments",
-    ]
 
     def formula(household, period, parameters):
         abolish_council_tax = parameters.gov.contrib.abolish_council_tax(period)
@@ -41,7 +43,7 @@ class household_tax(Variable):
             return add(
                 household,
                 period,
-                [tax for tax in household_tax.adds if tax not in ["council_tax"]],
+                [tax for tax in HOUSEHOLD_TAX_VARIABLES if tax not in ["council_tax"]],
             )
         else:
-            return add(household, period, household_tax.adds)
+            return add(household, period, HOUSEHOLD_TAX_VARIABLES)

--- a/policyengine_uk/variables/household/consumption/benunit_rent.py
+++ b/policyengine_uk/variables/household/consumption/benunit_rent.py
@@ -10,5 +10,4 @@ class benunit_rent(Variable):
     )
     definition_period = YEAR
     unit = GBP
-    uprating = "gov.economic_assumptions.indices.obr.social_rent"
     adds = ["personal_rent"]

--- a/policyengine_uk/variables/household/income/capital_gains.py
+++ b/policyengine_uk/variables/household/income/capital_gains.py
@@ -9,7 +9,6 @@ class capital_gains(Variable):
     definition_period = YEAR
     value_type = float
     unit = GBP
-    uprating = "gov.economic_assumptions.indices.obr.per_capita.gdp"
     adds = [
         "capital_gains_before_response",
         "capital_gains_behavioural_response",

--- a/policyengine_uk/variables/household/income/hbai_household_net_income.py
+++ b/policyengine_uk/variables/household/income/hbai_household_net_income.py
@@ -3,6 +3,69 @@ import datetime
 import numpy as np
 
 
+HBAI_HOUSEHOLD_NET_INCOME_ADDS = [
+    "employment_income",
+    "self_employment_income",
+    "savings_interest_income",
+    "dividend_income",
+    "miscellaneous_income",
+    "property_income",
+    "private_pension_income",
+    "private_transfer_income",
+    "maintenance_income",
+    "free_school_meals",
+    "free_school_fruit_veg",
+    "free_school_milk",
+    "free_tv_licence_value",
+    "child_benefit",
+    "council_tax_benefit",
+    "esa_income",
+    "esa_contrib",
+    "housing_benefit",
+    "income_support",
+    "jsa_income",
+    "jsa_contrib",
+    "pension_credit",
+    "universal_credit",
+    "working_tax_credit",
+    "child_tax_credit",
+    "attendance_allowance",
+    "afcs",
+    "bsp",
+    "carers_allowance",
+    "dla",
+    "iidb",
+    "incapacity_benefit",
+    "pip",
+    "sda",
+    "state_pension",
+    "maternity_allowance",
+    "statutory_sick_pay",
+    "statutory_maternity_pay",
+    "ssmg",
+    "cost_of_living_support_payment",
+    "winter_fuel_allowance",
+    "tax_free_childcare",
+    "healthy_start_vouchers",
+    "scottish_child_payment",
+    "carer_support_payment",
+    # Reference for tax-free-childcare: https://assets.publishing.service.gov.uk/media/5e7b191886650c744175d08b/households-below-average-income-1994-1995-2018-2019.pdf
+]
+
+HBAI_HOUSEHOLD_NET_INCOME_SUBTRACTS = [
+    "council_tax",
+    "domestic_rates",
+    "income_tax",
+    "national_insurance",
+    "student_loan_repayments",
+    "employee_pension_contributions",
+    "personal_pension_contributions",
+    "maintenance_expenses",
+    "external_child_payments",
+    "LVT",
+]
+
+
 class hbai_household_net_income(Variable):
     value_type = float
     entity = Household
@@ -11,79 +74,18 @@ class hbai_household_net_income(Variable):
     unit = GBP
     definition_period = YEAR
 
-    adds = [
-        "employment_income",
-        "self_employment_income",
-        "savings_interest_income",
-        "dividend_income",
-        "miscellaneous_income",
-        "property_income",
-        "private_pension_income",
-        "private_transfer_income",
-        "maintenance_income",
-        "free_school_meals",
-        "free_school_fruit_veg",
-        "free_school_milk",
-        "free_tv_licence_value",
-        "child_benefit",
-        "council_tax_benefit",
-        "esa_income",
-        "esa_contrib",
-        "housing_benefit",
-        "income_support",
-        "jsa_income",
-        "jsa_contrib",
-        "pension_credit",
-        "universal_credit",
-        "working_tax_credit",
-        "child_tax_credit",
-        "attendance_allowance",
-        "afcs",
-        "bsp",
-        "carers_allowance",
-        "dla",
-        "iidb",
-        "incapacity_benefit",
-        "pip",
-        "sda",
-        "state_pension",
-        "maternity_allowance",
-        "statutory_sick_pay",
-        "statutory_maternity_pay",
-        "ssmg",
-        "cost_of_living_support_payment",
-        "winter_fuel_allowance",
-        "tax_free_childcare",
-        "healthy_start_vouchers",
-        "scottish_child_payment",
-        "carer_support_payment",
-        # Reference for tax-free-childcare: https://assets.publishing.service.gov.uk/media/5e7b191886650c744175d08b/households-below-average-income-1994-1995-2018-2019.pdf
-    ]
-    subtracts = [
-        "council_tax",
-        "domestic_rates",
-        "income_tax",
-        "national_insurance",
-        "student_loan_repayments",
-        "employee_pension_contributions",
-        "personal_pension_contributions",
-        "maintenance_expenses",
-        "external_child_payments",
-        "LVT",
-    ]
-
     def formula(household, period, parameters):
         abolish_council_tax = parameters.gov.contrib.abolish_council_tax(period)
         if abolish_council_tax:
             adds = [
-                a for a in hbai_household_net_income.adds if a != "council_tax_benefit"
+                a for a in HBAI_HOUSEHOLD_NET_INCOME_ADDS if a != "council_tax_benefit"
             ]
             subtracts = [
-                s for s in hbai_household_net_income.subtracts if s != "council_tax"
+                s for s in HBAI_HOUSEHOLD_NET_INCOME_SUBTRACTS if s != "council_tax"
             ]
             return add(household, period, adds) - add(household, period, subtracts)
-        return add(household, period, hbai_household_net_income.adds) - add(
-            household, period, hbai_household_net_income.subtracts
+        return add(household, period, HBAI_HOUSEHOLD_NET_INCOME_ADDS) - add(
+            household, period, HBAI_HOUSEHOLD_NET_INCOME_SUBTRACTS
         )
 
 

--- a/policyengine_uk/variables/household/income/household_benefits.py
+++ b/policyengine_uk/variables/household/income/household_benefits.py
@@ -1,6 +1,60 @@
 from policyengine_uk.model_api import *
 
 
+HOUSEHOLD_BENEFIT_VARIABLES = [
+    "child_benefit",
+    "council_tax_benefit",
+    "esa_income",
+    "esa_contrib",
+    "housing_benefit",
+    "income_support",
+    "jsa_income",
+    "jsa_contrib",
+    "pension_credit",
+    "universal_credit",
+    "working_tax_credit",
+    "child_tax_credit",
+    "attendance_allowance",
+    "afcs",
+    "bsp",
+    "carers_allowance",
+    "dla",
+    "iidb",
+    "incapacity_benefit",
+    "jsa_contrib",
+    "pip",
+    "sda",
+    "state_pension",
+    "maternity_allowance",
+    "statutory_sick_pay",
+    "statutory_maternity_pay",
+    "ssmg",
+    "basic_income",
+    "epg_subsidy",
+    "cost_of_living_support_payment",
+    "energy_bills_rebate",
+    "winter_fuel_allowance",
+    "tax_free_childcare",
+    "extended_childcare_entitlement",
+    "universal_childcare_entitlement",
+    "targeted_childcare_entitlement",
+    "care_to_learn",
+    "childcare_grant",
+    "parents_learning_allowance",
+    "adult_dependants_grant",
+    "travel_grant",
+    "disabled_students_allowance",
+    "bursary_fund_16_to_19",
+    "nhs_spending",
+    "dfe_education_spending",
+    "dft_subsidy_spending",
+    "healthy_start_vouchers",
+    "two_child_limit_payment",
+    "scottish_child_payment",
+    "carer_support_payment",
+]
+
+
 class household_benefits(Variable):
     value_type = float
     entity = Household
@@ -8,63 +62,11 @@ class household_benefits(Variable):
     documentation = "Total value of benefits received by household"
     definition_period = YEAR
     unit = GBP
-    adds = [
-        "child_benefit",
-        "council_tax_benefit",
-        "esa_income",
-        "esa_contrib",
-        "housing_benefit",
-        "income_support",
-        "jsa_income",
-        "jsa_contrib",
-        "pension_credit",
-        "universal_credit",
-        "working_tax_credit",
-        "child_tax_credit",
-        "attendance_allowance",
-        "afcs",
-        "bsp",
-        "carers_allowance",
-        "dla",
-        "iidb",
-        "incapacity_benefit",
-        "jsa_contrib",
-        "pip",
-        "sda",
-        "state_pension",
-        "maternity_allowance",
-        "statutory_sick_pay",
-        "statutory_maternity_pay",
-        "ssmg",
-        "basic_income",
-        "epg_subsidy",
-        "cost_of_living_support_payment",
-        "energy_bills_rebate",
-        "winter_fuel_allowance",
-        "tax_free_childcare",
-        "extended_childcare_entitlement",
-        "universal_childcare_entitlement",
-        "targeted_childcare_entitlement",
-        "care_to_learn",
-        "childcare_grant",
-        "parents_learning_allowance",
-        "adult_dependants_grant",
-        "travel_grant",
-        "disabled_students_allowance",
-        "bursary_fund_16_to_19",
-        "nhs_spending",
-        "dfe_education_spending",
-        "dft_subsidy_spending",
-        "healthy_start_vouchers",
-        "two_child_limit_payment",
-        "scottish_child_payment",
-        "carer_support_payment",
-    ]
 
     def formula(household, period, parameters):
         contrib = parameters(period).gov.contrib
         uprating = contrib.benefit_uprating
-        benefits = household_benefits.adds
+        benefits = HOUSEHOLD_BENEFIT_VARIABLES
         if contrib.abolish_council_tax:
             benefits = [
                 benefit for benefit in benefits if benefit != "council_tax_benefit"

--- a/policyengine_uk/variables/household/income/household_market_income.py
+++ b/policyengine_uk/variables/household/income/household_market_income.py
@@ -3,6 +3,20 @@ import datetime
 import numpy as np
 
 
+HOUSEHOLD_MARKET_INCOME_VARIABLES = [
+    "employment_income",
+    "self_employment_income",
+    "savings_interest_income",
+    "dividend_income",
+    "miscellaneous_income",
+    "property_income",
+    "private_pension_income",
+    "private_transfer_income",
+    "maintenance_income",
+    "capital_gains",
+]
+
+
 class household_market_income(Variable):
     value_type = float
     entity = Household
@@ -10,20 +24,8 @@ class household_market_income(Variable):
     documentation = "Market income for the household"
     definition_period = YEAR
     unit = GBP
-    adds = [
-        "employment_income",
-        "self_employment_income",
-        "savings_interest_income",
-        "dividend_income",
-        "miscellaneous_income",
-        "property_income",
-        "private_pension_income",
-        "private_transfer_income",
-        "maintenance_income",
-        "capital_gains",
-    ]
 
     def formula(person, period, parameters):
-        total = add(person, period, household_market_income.adds)
+        total = add(person, period, HOUSEHOLD_MARKET_INCOME_VARIABLES)
         contrib = parameters(period).gov.contrib.policyengine.economy.gdp_per_capita
         return total * (contrib + 1)

--- a/policyengine_uk/variables/input/employment_income.py
+++ b/policyengine_uk/variables/input/employment_income.py
@@ -17,4 +17,3 @@ class employment_income(Variable):
         "salary_sacrifice_returned_to_income",
         "salary_sacrifice_broad_base_haircut",
     ]
-    uprating = "gov.economic_assumptions.indices.obr.average_earnings"

--- a/policyengine_uk/variables/input/state_pension.py
+++ b/policyengine_uk/variables/input/state_pension.py
@@ -9,7 +9,6 @@ class state_pension(Variable):
     unit = GBP
     documentation = "Gross State Pension payments"
     quantity_type = FLOW
-    uprating = "gov.economic_assumptions.indices.obr.consumer_price_index"
 
     def formula(person, period, parameters):
         contrib = parameters.gov.contrib


### PR DESCRIPTION
## Summary
- remove redundant `uprating` metadata from variables already computed by `adds`
- move aggregation lists used by formulas to module constants so variables no longer declare both formula and `adds`/`subtracts`
- keep a changelog fragment so this cleanup releases before PolicyEngine Core enforces mutually exclusive computation modes

## Verification
- AST scan for variables mixing formula, `adds`/`subtracts`, and `uprating`: `conflicts=0`
- `uv run --no-sync ruff check` on touched variable files
- `uv run --no-sync ruff format --check` on touched variable files
- `uv run --no-sync python -c "from policyengine_uk import CountryTaxBenefitSystem; CountryTaxBenefitSystem(); print('uk import OK')"`
- `PYTHONPATH=/Users/maxghenis/policyengine-core uv run --no-sync python -c "from policyengine_uk import CountryTaxBenefitSystem; CountryTaxBenefitSystem(); print('uk import OK with local core')"`
- `uv run --with towncrier towncrier build --draft --version 2.88.18`

Companion cleanup for US: PolicyEngine/policyengine-us#8330. Core guard PR to follow after UK and US releases are live.