### PR TITLE
Add net_wealth variable and mortgage_debt / consumer_debt inputs

### DIFF
--- a/changelog.d/net-wealth.added.md
+++ b/changelog.d/net-wealth.added.md
@@ -1,0 +1,1 @@
+Added `net_wealth` (total wealth net of mortgage, consumer, and student loan debt) and the `mortgage_debt` and `consumer_debt` household inputs. Unlike gross `total_wealth`, net wealth can be negative when a household's debts exceed its assets.

--- a/policyengine_uk/tests/policy/baseline/household/wealth/net_wealth.yaml
+++ b/policyengine_uk/tests/policy/baseline/household/wealth/net_wealth.yaml
@@ -1,0 +1,27 @@
+- name: Net wealth subtracts mortgage, consumer and student-loan debt
+  period: 2026
+  absolute_error_margin: 1
+  input:
+    total_wealth: 500_000
+    mortgage_debt: 200_000
+    consumer_debt: 10_000
+    student_loan_balance: 15_000
+  output:
+    net_wealth: 275_000
+
+- name: Net wealth is negative when debts exceed assets
+  period: 2026
+  absolute_error_margin: 1
+  input:
+    total_wealth: 50_000
+    mortgage_debt: 120_000
+  output:
+    net_wealth: -70_000
+
+- name: Net wealth equals total wealth with no debt
+  period: 2026
+  absolute_error_margin: 1
+  input:
+    total_wealth: 300_000
+  output:
+    net_wealth: 300_000

--- a/policyengine_uk/variables/household/wealth/net_wealth.py
+++ b/policyengine_uk/variables/household/wealth/net_wealth.py
@@ -1,0 +1,22 @@
+from policyengine_uk.model_api import *
+
+
+class net_wealth(Variable):
+    label = "Net wealth"
+    documentation = (
+        "Total wealth less mortgage, consumer, and student loan debt. Unlike "
+        "total_wealth (gross assets), net wealth can be negative when a "
+        "household's debts exceed its assets."
+    )
+    entity = Household
+    definition_period = YEAR
+    value_type = float
+    unit = GBP
+    quantity_type = STOCK
+
+    def formula(household, period, parameters):
+        total_wealth = household("total_wealth", period)
+        mortgage_debt = household("mortgage_debt", period)
+        consumer_debt = household("consumer_debt", period)
+        student_loan_debt = add(household, period, ["student_loan_balance"])
+        return total_wealth - mortgage_debt - consumer_debt - student_loan_debt

--- a/policyengine_uk/variables/input/consumer_debt.py
+++ b/policyengine_uk/variables/input/consumer_debt.py
@@ -1,0 +1,13 @@
+from policyengine_uk.model_api import *
+
+
+class consumer_debt(Variable):
+    label = "consumer debt"
+    documentation = "Outstanding non-mortgage, non-student-loan borrowing (personal loans, credit, hire purchase), imputed from the Wealth and Assets Survey"
+    entity = Household
+    definition_period = YEAR
+    value_type = float
+    unit = GBP
+    uprating = "gov.economic_assumptions.indices.obr.per_capita.gdp"
+    quantity_type = STOCK
+    default_value = 0

--- a/policyengine_uk/variables/input/mortgage_debt.py
+++ b/policyengine_uk/variables/input/mortgage_debt.py
@@ -1,0 +1,13 @@
+from policyengine_uk.model_api import *
+
+
+class mortgage_debt(Variable):
+    label = "mortgage debt"
+    documentation = "Outstanding debt secured on UK land or property (mortgages and secured loans), imputed from the Wealth and Assets Survey"
+    entity = Household
+    definition_period = YEAR
+    value_type = float
+    unit = GBP
+    uprating = "gov.economic_assumptions.indices.obr.per_capita.gdp"
+    quantity_type = STOCK
+    default_value = 0


### PR DESCRIPTION
## What

Adds a `net_wealth` household variable and the `mortgage_debt` and `consumer_debt` inputs that feed it.

- `net_wealth` = `total_wealth` − `mortgage_debt` − `consumer_debt` − household `student_loan_balance`.
- `mortgage_debt` (gross outstanding mortgage) and `consumer_debt` (non-mortgage, non-student-loan borrowing) are new household inputs.

## Why

Gross `total_wealth` (property + corporate + savings) has no liabilities netted out, so it is never negative. That makes the bottom of the wealth distribution an artefact: ~13% of households own no property/savings and pile up at exactly £0, leaving the lowest wealth decile empty and hiding the genuinely underwater households (debts > assets). `net_wealth` puts those households where they belong — the bottom of the distribution — so distributional analysis by wealth reflects reality.

`total_wealth` is left unchanged (the web app's percentage wealth-change charts rely on it staying non-negative).

## Companion

The `mortgage_debt` / `consumer_debt` inputs are imputed from the Wealth and Assets Survey by a companion **policyengine-uk-data** PR. Until a dataset release carries them, both default to 0 (so `net_wealth` == `total_wealth`).

## Tests

`policyengine_uk/tests/policy/baseline/household/wealth/net_wealth.yaml` covers the subtraction, a negative-net-wealth case, and the no-debt case.
